### PR TITLE
5718 Add basic DeckGL Map with NTA layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,12 @@
         "@chakra-ui/theme-tools": "^1.1.2",
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
+        "deck.gl": "^8.6.4",
         "framer-motion": "^4.1.17",
         "next": "latest",
         "react": "^17.0.2",
-        "react-dom": "^17.0.2"
+        "react-dom": "^17.0.2",
+        "react-map-gl": "^6.1.17"
       },
       "devDependencies": {
         "@babel/core": "^7.16.0",
@@ -1541,6 +1543,161 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/@deck.gl/aggregation-layers": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-8.6.4.tgz",
+      "integrity": "sha512-tcHaY6wyFtfggqVd0jWJSQyvSq4aToDJDwVLEb6ki80sWWsgNw5+eM51yhAsCzY+/ce74dI7Ou7sAtrGLON+xA==",
+      "dependencies": {
+        "@luma.gl/shadertools": "^8.5.10",
+        "@math.gl/web-mercator": "^3.5.4",
+        "d3-hexbin": "^0.2.1"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^8.0.0",
+        "@deck.gl/layers": "^8.0.0"
+      }
+    },
+    "node_modules/@deck.gl/carto": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/carto/-/carto-8.6.4.tgz",
+      "integrity": "sha512-vvAVhcEU6LIYlqc4kKGwxlHGKiDSAq8AXOstfTnUHWt2+fYfseFb+P+h+GubBxqyoeRzmeTviZQ76wSeUqcXiw==",
+      "dependencies": {
+        "@loaders.gl/loader-utils": "^3.0.8",
+        "@loaders.gl/mvt": "^3.0.8",
+        "@loaders.gl/tiles": "^3.0.8",
+        "@math.gl/web-mercator": "^3.5.4",
+        "cartocolor": "^4.0.2",
+        "d3-scale": "^3.2.3"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^8.0.0",
+        "@deck.gl/geo-layers": "^8.0.0",
+        "@deck.gl/layers": "^8.0.0",
+        "@loaders.gl/core": "^3.0.0"
+      }
+    },
+    "node_modules/@deck.gl/core": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-8.6.4.tgz",
+      "integrity": "sha512-veSW3VSOsm+mYzWIoqn6GZlRzADy2uX2xX4vOGZ06dCdSTrF6LqcyINsEftcqbpznME0ugpsTVIXj3P15LESQA==",
+      "dependencies": {
+        "@loaders.gl/core": "^3.0.8",
+        "@loaders.gl/images": "^3.0.8",
+        "@luma.gl/core": "^8.5.10",
+        "@math.gl/web-mercator": "^3.5.4",
+        "gl-matrix": "^3.0.0",
+        "math.gl": "^3.5.4",
+        "mjolnir.js": "^2.5.0",
+        "probe.gl": "^3.4.0"
+      }
+    },
+    "node_modules/@deck.gl/extensions": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-8.6.4.tgz",
+      "integrity": "sha512-sYT9lcuVWmnnmXpgjNqtRPYmVq94+aMiW7FgQNN0KkNKYFlDEyjy5CrrWlWosS2dVDQuS2WRPQ6Hm12VRvCsyQ==",
+      "dependencies": {
+        "@luma.gl/shadertools": "^8.5.10"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^8.0.0",
+        "gl-matrix": "^3.0.0"
+      }
+    },
+    "node_modules/@deck.gl/geo-layers": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-8.6.4.tgz",
+      "integrity": "sha512-NNEkaBy9YdCq31eG6rYgz6vfmvnP1/52oqlDAHveAs3DTchLXOszvh8tD17mAp1ox3Nc4aewW6EopXbDChpw4Q==",
+      "dependencies": {
+        "@loaders.gl/3d-tiles": "^3.0.8",
+        "@loaders.gl/gis": "^3.0.8",
+        "@loaders.gl/loader-utils": "^3.0.8",
+        "@loaders.gl/mvt": "^3.0.8",
+        "@loaders.gl/terrain": "^3.0.8",
+        "@loaders.gl/tiles": "^3.0.8",
+        "@luma.gl/experimental": "^8.5.10",
+        "@math.gl/culling": "^3.5.4",
+        "@math.gl/web-mercator": "^3.5.4",
+        "h3-js": "^3.6.0",
+        "long": "^3.2.0",
+        "math.gl": "^3.5.4"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^8.0.0",
+        "@deck.gl/extensions": "^8.0.0",
+        "@deck.gl/layers": "^8.0.0",
+        "@deck.gl/mesh-layers": "^8.0.0",
+        "@loaders.gl/core": "^3.0.0"
+      }
+    },
+    "node_modules/@deck.gl/google-maps": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/google-maps/-/google-maps-8.6.4.tgz",
+      "integrity": "sha512-D9h6oa4E6Yqq9eZoTz7PZXL8vFuNhjVF3sT0Onf6F/f+HrMXzWkVUNBX0Enn1tYk0LOOyqs0qeD/eCJihbPW0Q==",
+      "peerDependencies": {
+        "@deck.gl/core": "^8.0.0"
+      }
+    },
+    "node_modules/@deck.gl/json": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/json/-/json-8.6.4.tgz",
+      "integrity": "sha512-VV5hBxjezkmS7mpfpxPUI5j00KfVf987K4jZUjHraoppdaKL1Rup+Lfi8wF8oSHovnufiu7xvz+FeZZOdp3u+w==",
+      "dependencies": {
+        "d3-dsv": "^1.0.8",
+        "expression-eval": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^8.0.0"
+      }
+    },
+    "node_modules/@deck.gl/layers": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-8.6.4.tgz",
+      "integrity": "sha512-G2L9r6O3NsmiIidFrqU5YUBZWnwnfOf5GVqBw6KOj9+b0HTPNLJ6xuswzGnjmf4fILgknOXtLm6IrLjLNoCCDw==",
+      "dependencies": {
+        "@loaders.gl/images": "^3.0.8",
+        "@mapbox/tiny-sdf": "^1.1.0",
+        "@math.gl/polygon": "^3.5.4",
+        "earcut": "^2.0.6"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^8.0.0",
+        "@loaders.gl/core": "^3.0.0"
+      }
+    },
+    "node_modules/@deck.gl/mapbox": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-8.6.4.tgz",
+      "integrity": "sha512-HD8pFW/9SMU0Idj/iilAFkwzko62UpVCN/UFixZ8wEU7+1zjxJVqP+uxZVUWpHJ2MgREp47FNlVTwdbFijMVLw==",
+      "peerDependencies": {
+        "@deck.gl/core": "^8.0.0"
+      }
+    },
+    "node_modules/@deck.gl/mesh-layers": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-8.6.4.tgz",
+      "integrity": "sha512-WoJZR02PF5Ypd3X2c7vaF3rMHWcBVxdcnQ+SDFunebd+n+5H8zKJqxm0F+KMhSN7OhOW/K6NeT5ieMcDKkxniQ==",
+      "dependencies": {
+        "@loaders.gl/gltf": "^3.0.8",
+        "@luma.gl/experimental": "^8.5.10",
+        "@luma.gl/shadertools": "^8.5.10"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^8.0.0"
+      }
+    },
+    "node_modules/@deck.gl/react": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-8.6.4.tgz",
+      "integrity": "sha512-k1S5Cpv5DdZyNa9miwbThyZJATAXTt9Ism6w1bGRa2LsgjUXUCmNhlCEdqPhYrRYYltg8x35WV8xa0UrafUqvA==",
+      "dependencies": {
+        "prop-types": "^15.6.0"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^8.0.0",
+        "react": ">=16.3",
+        "react-dom": ">=16.3"
+      }
+    },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.3.0",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.3.0.tgz",
@@ -2535,6 +2692,352 @@
         "node": ">=8"
       }
     },
+    "node_modules/@loaders.gl/3d-tiles": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-3.0.13.tgz",
+      "integrity": "sha512-irR5IybohU7vFg6gSdmrtOdMokFCOzAWUJRdy/K42qssbHVhZlB8EO0Y1P+JhYuBHvtskNhHfM9IBTJbjgfWBw==",
+      "dependencies": {
+        "@loaders.gl/core": "3.0.13",
+        "@loaders.gl/draco": "3.0.13",
+        "@loaders.gl/gltf": "3.0.13",
+        "@loaders.gl/loader-utils": "3.0.13",
+        "@loaders.gl/math": "3.0.13",
+        "@loaders.gl/tiles": "3.0.13",
+        "@math.gl/core": "^3.5.1",
+        "@math.gl/geospatial": "^3.5.1"
+      }
+    },
+    "node_modules/@loaders.gl/core": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-3.0.13.tgz",
+      "integrity": "sha512-Bi+VeITyRJtQLLx9YARpb4JzFkhXmKDiS2JVxdg5mn4i1QrzrLM0hPbtb4H6sNJ9S0WhFe3ikrXenGo/DL/aNw==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "@loaders.gl/loader-utils": "3.0.13",
+        "@loaders.gl/worker-utils": "3.0.13",
+        "probe.gl": "^3.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/draco": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-3.0.13.tgz",
+      "integrity": "sha512-M9RCQHtqpAB1PK3HvXR2LJqBVhIdbndUie3lrWMGP4NFDGnDnDlTk7Kk/QEbgpidafdEbUiJEU/4/uEzYFA4Kw==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "@loaders.gl/loader-utils": "3.0.13",
+        "@loaders.gl/schema": "3.0.13",
+        "@loaders.gl/worker-utils": "3.0.13",
+        "draco3d": "1.4.1"
+      }
+    },
+    "node_modules/@loaders.gl/gis": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-3.0.13.tgz",
+      "integrity": "sha512-pftgUaKJ65gFwNyi+a2NGwjW8M5FlLZYnhKHjQ5/lNMYsodwSxp7HrJR5RKON+x6P7gaxjBgoCMDrAgWKNCDHQ==",
+      "dependencies": {
+        "@loaders.gl/loader-utils": "3.0.13",
+        "@loaders.gl/schema": "3.0.13",
+        "@mapbox/vector-tile": "^1.3.1",
+        "pbf": "^3.2.1"
+      }
+    },
+    "node_modules/@loaders.gl/gltf": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-3.0.13.tgz",
+      "integrity": "sha512-QRzHFNxyz/f0QuyCvtreuOYr4cxfQvr141UWHQDPbgYgQpZlXa/JSP2/lTbXpaxd5LNLwHyNbDvpqv9u4bUwlw==",
+      "dependencies": {
+        "@loaders.gl/core": "3.0.13",
+        "@loaders.gl/draco": "3.0.13",
+        "@loaders.gl/images": "3.0.13",
+        "@loaders.gl/loader-utils": "3.0.13"
+      }
+    },
+    "node_modules/@loaders.gl/images": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-3.0.13.tgz",
+      "integrity": "sha512-w4I80tUoVg7Df3OWnxbjZWgGEpf1pLqbxGC8j8lhB3na8n5CnEllt6iN94dnwawDlfDX9wTHXNNaCTIguYsv0Q==",
+      "dependencies": {
+        "@loaders.gl/loader-utils": "3.0.13"
+      }
+    },
+    "node_modules/@loaders.gl/loader-utils": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-3.0.13.tgz",
+      "integrity": "sha512-tVDmytWaO1XHBV9F5UEQd55vAdnVDZhK2nUKY5oBfDlo1mG5PhXWOj2Za+yV4btMC86PWXYhLiUUgy+9vABPOw==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "@loaders.gl/worker-utils": "3.0.13",
+        "@probe.gl/stats": "^3.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/math": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-3.0.13.tgz",
+      "integrity": "sha512-FMqJrOgO6IYxSW6ZhHpLKCLeP/1f4ASFZzo6J9CdON1MHv4YJ8jc1hDlDaiRDnOEl6ANCHvuSSVjUt9ML/XXgw==",
+      "dependencies": {
+        "@loaders.gl/images": "3.0.13",
+        "@loaders.gl/loader-utils": "3.0.13",
+        "@math.gl/core": "^3.5.1"
+      }
+    },
+    "node_modules/@loaders.gl/mvt": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-3.0.13.tgz",
+      "integrity": "sha512-bo7ObDohK7sBlk4Y1WUjg8X2HQ6O9UaxhUmkJruceCtRpy1h7lqOEtxfwdFHXPWGCEUz27zhkk2dNtV8HffAbg==",
+      "dependencies": {
+        "@loaders.gl/gis": "3.0.13",
+        "@loaders.gl/loader-utils": "3.0.13",
+        "@math.gl/polygon": "^3.5.1",
+        "pbf": "^3.2.1"
+      }
+    },
+    "node_modules/@loaders.gl/schema": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-3.0.13.tgz",
+      "integrity": "sha512-w6jPTnaSE/d5EfIKSVNRGFxUb56EiJrbKBUbZ6OgRkBlDlmSbLvRoaH/Jz5TT8ewK7DF6pumMqTXJ/0n0SZ5Pw==",
+      "dependencies": {
+        "@types/geojson": "^7946.0.7",
+        "apache-arrow": "^4.0.0",
+        "d3-dsv": "^1.2.0"
+      }
+    },
+    "node_modules/@loaders.gl/terrain": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-3.0.13.tgz",
+      "integrity": "sha512-trUnxKFWGuHonIrQy4DvNjtRZZ+qgymS9xqKe3iZ7wqu9Ho/7ZbdnPzt75vIM1QQiDHSNiccBsq2Nr8g1BDuXg==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "@loaders.gl/loader-utils": "3.0.13",
+        "@loaders.gl/schema": "3.0.13",
+        "@mapbox/martini": "^0.2.0"
+      }
+    },
+    "node_modules/@loaders.gl/tiles": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-3.0.13.tgz",
+      "integrity": "sha512-mkbBIEXsVVEsVpkXkQrATG25Iw3lYaeHMVem4xCpCHQHV5d8cFyLnXBzWi/cWRzfEk+dAMT7g+LkxH39rG43og==",
+      "dependencies": {
+        "@loaders.gl/core": "3.0.13",
+        "@loaders.gl/loader-utils": "3.0.13",
+        "@loaders.gl/math": "3.0.13",
+        "@math.gl/core": "^3.5.1",
+        "@math.gl/culling": "^3.5.1",
+        "@math.gl/geospatial": "^3.5.1",
+        "@math.gl/web-mercator": "^3.5.1",
+        "@probe.gl/stats": "^3.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/worker-utils": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-3.0.13.tgz",
+      "integrity": "sha512-QB4jZumKGsouJprPzNKnKXTXMLf89afBwmi4Rnnw4SVj49olPiAGh4FZjf00GHFHKZlvAj8LB5rfqwd+Te6IVA==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1"
+      }
+    },
+    "node_modules/@luma.gl/constants": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-8.5.10.tgz",
+      "integrity": "sha512-0OZnNbb8hF+ogr/Exr5KFEnSMQdCgjrbO2ZYeNIGO0UVMTu4oTSLfRcBxKUs1NzxG5RogyV8dL6ETQbkP5VAZw=="
+    },
+    "node_modules/@luma.gl/core": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-8.5.10.tgz",
+      "integrity": "sha512-NzzMnSgzPta3gMu8vSM/kWiY09HypHRXt4zw/xFX4geLeX4iXm7Jnm+eeaNpc/QH/yJ51+4bpvZml0P5NIukfQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@luma.gl/constants": "8.5.10",
+        "@luma.gl/engine": "8.5.10",
+        "@luma.gl/gltools": "8.5.10",
+        "@luma.gl/shadertools": "8.5.10",
+        "@luma.gl/webgl": "8.5.10"
+      }
+    },
+    "node_modules/@luma.gl/engine": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-8.5.10.tgz",
+      "integrity": "sha512-W3cPlabMl1g6dfAio4yGD9GohoMULXqsBm9P9WOh0KypQBw5pFlE2C/njY43YhfvnpMPDMUjjraYrEXa1fhaig==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@luma.gl/constants": "8.5.10",
+        "@luma.gl/gltools": "8.5.10",
+        "@luma.gl/shadertools": "8.5.10",
+        "@luma.gl/webgl": "8.5.10",
+        "@math.gl/core": "^3.5.0",
+        "probe.gl": "^3.4.0"
+      }
+    },
+    "node_modules/@luma.gl/experimental": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@luma.gl/experimental/-/experimental-8.5.10.tgz",
+      "integrity": "sha512-1Ldq2DEor9qWHoRetcAz4BID1pwp+5x67F2mfe2UtjEpDY0Modi7t8C94PR8cviyjRIu3DErxX7o8HxJ4JXxpQ==",
+      "dependencies": {
+        "@luma.gl/constants": "8.5.10",
+        "@math.gl/core": "^3.5.0",
+        "earcut": "^2.0.6"
+      },
+      "peerDependencies": {
+        "@loaders.gl/gltf": "^3.0.0",
+        "@loaders.gl/images": "^3.0.0",
+        "@luma.gl/engine": "^8.4.0",
+        "@luma.gl/gltools": "^8.4.0",
+        "@luma.gl/shadertools": "^8.4.0",
+        "@luma.gl/webgl": "^8.4.0"
+      }
+    },
+    "node_modules/@luma.gl/gltools": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@luma.gl/gltools/-/gltools-8.5.10.tgz",
+      "integrity": "sha512-XQFocLXvSYfkW2xL1I50nYrPwgyt1jvmzmood3RQBQMiBcgU1JFW2w4tU+V/C5QXcAWWVzm8aIBkuQsCo34zrQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@luma.gl/constants": "8.5.10",
+        "probe.gl": "^3.4.0"
+      }
+    },
+    "node_modules/@luma.gl/shadertools": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-8.5.10.tgz",
+      "integrity": "sha512-Va/e7fHFI7ZWu03obtNlXN7noIUF1u9U3Pm6PVqeVi3Z24yWl/pFbb5/O1gn66LQZF6fpwoLGN7m4NGk2YyHyA==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@math.gl/core": "^3.5.0"
+      }
+    },
+    "node_modules/@luma.gl/webgl": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-8.5.10.tgz",
+      "integrity": "sha512-8cCJ6aoKmVKvrYoPC6G1jHqMsfTGyn50YMmRkrk2Q79nBe531LZr+6EYXlqx2+AR9obKwTnhTPlxjKg5gR4rYg==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@luma.gl/constants": "8.5.10",
+        "@luma.gl/gltools": "8.5.10",
+        "probe.gl": "^3.4.0"
+      }
+    },
+    "node_modules/@mapbox/geojson-rewind": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.1.tgz",
+      "integrity": "sha512-eL7fMmfTBKjrb+VFHXCGv9Ot0zc3C0U+CwXo1IrP+EPwDczLoXv34Tgq3y+2mPSFNVUXgU42ILWJTC7145KPTA==",
+      "dependencies": {
+        "get-stream": "^6.0.1",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "geojson-rewind": "geojson-rewind"
+      }
+    },
+    "node_modules/@mapbox/geojson-rewind/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mapbox/geojson-types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
+      "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw=="
+    },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/mapbox-gl-supported": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-2.0.1.tgz",
+      "integrity": "sha512-HP6XvfNIzfoMVfyGjBckjiAOQK9WfX0ywdLubuPMPv+Vqf5fj0uCbgBQYpiqcWZT6cbyyRnTSXDheT1ugvF6UQ=="
+    },
+    "node_modules/@mapbox/martini": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/martini/-/martini-0.2.0.tgz",
+      "integrity": "sha512-7hFhtkb0KTLEls+TRw/rWayq5EeHtTaErgm/NskVoXmtgAQu/9D299aeyj6mzAR/6XUnYRp2lU+4IcrYRFjVsQ=="
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
+      "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw=="
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
+      "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4="
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "dependencies": {
+        "@mapbox/point-geometry": "~0.1.0"
+      }
+    },
+    "node_modules/@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@math.gl/core": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-3.5.6.tgz",
+      "integrity": "sha512-UGCKtJUBA9MBswclK6l8DuZqLcEnqlSfI57WzSDUB/Nki4tHfmdImJyhp8ky9W4cIahV1YLMhHRK1oRpLeC1sw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "gl-matrix": "~3.3.0"
+      }
+    },
+    "node_modules/@math.gl/culling": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/@math.gl/culling/-/culling-3.5.6.tgz",
+      "integrity": "sha512-Sustyo3XRaGVeUAzKk9kzoWErfNUzi+YFsmLe00r4qLbzXPg0Z7uLGX6zloEELILgqOZMOuAhadfmWVMsbq8ZA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "@math.gl/core": "3.5.6",
+        "gl-matrix": "~3.3.0"
+      }
+    },
+    "node_modules/@math.gl/geospatial": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/@math.gl/geospatial/-/geospatial-3.5.6.tgz",
+      "integrity": "sha512-pYdnVeqbR5ybvUl+vOn1Ybj3BEwXk44vuU+VxE/GFKlM9M2oQlOisdJ8v6lyUDu7mEx6t5xsu8VUwMz1PymKLQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "@math.gl/core": "3.5.6",
+        "gl-matrix": "~3.3.0"
+      }
+    },
+    "node_modules/@math.gl/polygon": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-3.5.6.tgz",
+      "integrity": "sha512-CUGPmD8Y9elPRsb4+wG0nuElbEYcTK+Azks96M9zleMaOACUDqUY6D4rDtqpyEIeqcun85Aq+7eV/rjVMahWgA==",
+      "dependencies": {
+        "@math.gl/core": "3.5.6"
+      }
+    },
+    "node_modules/@math.gl/web-mercator": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.5.6.tgz",
+      "integrity": "sha512-siWHLJGp9o8fDEM1t0Rby+JXftl6il0z3927liWGzkHqFftXPHY858ShPy45ThDU8q5lyCftg8aVgrv4nfD+Zw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "gl-matrix": "~3.3.0"
+      }
+    },
     "node_modules/@napi-rs/triples": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@napi-rs/triples/-/triples-1.0.3.tgz",
@@ -2916,6 +3419,14 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@probe.gl/stats": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-3.4.1.tgz",
+      "integrity": "sha512-1Ol5cH8MQqIrGNgU4NCBj2cw1qiXYfHP1QCFX+u/xyrvgwLkPrOGkdSYMzw4VKTjJzNae4i7urOTf2m2hduZzQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0"
+      }
+    },
     "node_modules/@reach/alert": {
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/@reach/alert/-/alert-0.13.2.tgz",
@@ -3292,6 +3803,16 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/flatbuffers": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@types/flatbuffers/-/flatbuffers-1.10.0.tgz",
+      "integrity": "sha512-7btbphLrKvo5yl/5CC2OCxUSMx1wV1wvGT1qDXkSt7yi00/YW7E8k6qzXqJHsp+WU0eoG7r6MTQQXI9lIvd0qA=="
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.8",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
+      "integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA=="
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -3358,6 +3879,14 @@
       "integrity": "sha512-RY/8IaVENjG19rxTZu9Nukqh0W2UrYgmBj5sdns4hWRZaV8PqR7wIKHFKzvOTjo4zVRV7sVI+yFhAJql12Kfqg==",
       "dependencies": {
         "@types/lodash": "*"
+      }
+    },
+    "node_modules/@types/mapbox-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.4.2.tgz",
+      "integrity": "sha512-mKgjmhUN780YGy9ZEyJK0Sr9gMtERmTQimGsIa5WrBHPlBXdmjYfqtz8nSMI7hOnQFphcuSMyqQswaQESFLHsA==",
+      "dependencies": {
+        "@types/geojson": "*"
       }
     },
     "node_modules/@types/node": {
@@ -3440,6 +3969,11 @@
       "dependencies": {
         "@types/jest": "*"
       }
+    },
+    "node_modules/@types/text-encoding-utf-8": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
+      "integrity": "sha512-AQ6zewa0ucLJvtUi5HsErbOFKAcQfRLt9zFLlUOvcXBy2G36a+ZDpCHSGdzJVUD8aNURtIjh9aSjCStNMRCcRQ=="
     },
     "node_modules/@types/warning": {
       "version": "3.0.0",
@@ -3832,6 +4366,26 @@
         "node": ">= 8"
       }
     },
+    "node_modules/apache-arrow": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-4.0.1.tgz",
+      "integrity": "sha512-DyF7GXCbSjsw4P5C8b+qW7OnJKa6w9mJI0mhV0+EfZbVZCmhfiF6ffqcnrI/kzBrRqn9hH/Ft9n5+m4DTbBJpg==",
+      "dependencies": {
+        "@types/flatbuffers": "^1.10.0",
+        "@types/node": "^14.14.37",
+        "@types/text-encoding-utf-8": "^1.0.1",
+        "command-line-args": "5.1.1",
+        "command-line-usage": "6.1.1",
+        "flatbuffers": "1.12.0",
+        "json-bignum": "^0.0.3",
+        "pad-left": "^2.1.0",
+        "text-encoding-utf-8": "^1.0.2",
+        "tslib": "^2.2.0"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.js"
+      }
+    },
     "node_modules/arch": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
@@ -3888,6 +4442,14 @@
       },
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/array-includes": {
@@ -4588,6 +5150,14 @@
         "url": "https://opencollective.com/browserslist"
       }
     },
+    "node_modules/cartocolor": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/cartocolor/-/cartocolor-4.0.2.tgz",
+      "integrity": "sha512-+Gh9mb6lFxsDOLQlBLPxAHCnWXlg2W8q3AcVwqRcy95TdBbcOU89Wrb6h2Hd/6Ww1Kc1pzXmUdpnWD+xeCG0dg==",
+      "dependencies": {
+        "colorbrewer": "1.0.0"
+      }
+    },
     "node_modules/caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -4781,6 +5351,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "node_modules/colorbrewer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/colorbrewer/-/colorbrewer-1.0.0.tgz",
+      "integrity": "sha1-T5czO5abp2Ejgr5LwzlLNB+0yKI="
+    },
     "node_modules/colorette": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
@@ -4806,6 +5381,50 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/command-line-args": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
+      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
+      "dependencies": {
+        "array-back": "^3.0.1",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.1.tgz",
+      "integrity": "sha512-F59pEuAR9o1SF/bD0dQBDluhpT4jJQNWUHEuVBqpDmCUo6gPjCi+m9fCWnWZVR/oG6cMTUms4h+3NPl74wGXvA==",
+      "dependencies": {
+        "array-back": "^4.0.1",
+        "chalk": "^2.4.2",
+        "table-layout": "^1.0.1",
+        "typical": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/array-back": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/commander": {
@@ -5001,6 +5620,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/csscolorparser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
+      "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs="
     },
     "node_modules/cssnano-preset-simple": {
       "version": "3.0.0",
@@ -5200,6 +5824,102 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+    },
+    "node_modules/d3-dsv": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.2.0.tgz",
+      "integrity": "sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==",
+      "dependencies": {
+        "commander": "2",
+        "iconv-lite": "0.4",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json",
+        "csv2tsv": "bin/dsv2dsv",
+        "dsv2dsv": "bin/dsv2dsv",
+        "dsv2json": "bin/dsv2json",
+        "json2csv": "bin/json2dsv",
+        "json2dsv": "bin/json2dsv",
+        "json2tsv": "bin/json2dsv",
+        "tsv2csv": "bin/dsv2dsv",
+        "tsv2json": "bin/dsv2json"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/d3-dsv/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
+      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
+    },
+    "node_modules/d3-hexbin": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/d3-hexbin/-/d3-hexbin-0.2.2.tgz",
+      "integrity": "sha1-nFg32s/UcasFM3qeke8Qv8T5iDE="
+    },
+    "node_modules/d3-interpolate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "dependencies": {
+        "d3-color": "1 - 2"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
+      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
+      "dependencies": {
+        "d3-array": "^2.3.0",
+        "d3-format": "1 - 2",
+        "d3-interpolate": "1.2.0 - 2",
+        "d3-time": "^2.1.1",
+        "d3-time-format": "2 - 3"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "dependencies": {
+        "d3-array": "2"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "dependencies": {
+        "d3-time": "1 - 2"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.7.tgz",
@@ -5268,6 +5988,24 @@
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
       "dev": true
     },
+    "node_modules/deck.gl": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/deck.gl/-/deck.gl-8.6.4.tgz",
+      "integrity": "sha512-FC5EPMlhluthqK7knzhCOm1UVj3TDQp/f6IFkZd0Jdn1G0ECKq9MkmCJEeaOXcPWA8LBaTtIJSeSNetW5bKAOw==",
+      "dependencies": {
+        "@deck.gl/aggregation-layers": "8.6.4",
+        "@deck.gl/carto": "8.6.4",
+        "@deck.gl/core": "8.6.4",
+        "@deck.gl/extensions": "8.6.4",
+        "@deck.gl/geo-layers": "8.6.4",
+        "@deck.gl/google-maps": "8.6.4",
+        "@deck.gl/json": "8.6.4",
+        "@deck.gl/layers": "8.6.4",
+        "@deck.gl/mapbox": "8.6.4",
+        "@deck.gl/mesh-layers": "8.6.4",
+        "@deck.gl/react": "8.6.4"
+      }
+    },
     "node_modules/decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -5282,6 +6020,14 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -5435,11 +6181,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/draco3d": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.4.1.tgz",
+      "integrity": "sha512-9Rxonc70xiovBC+Bq1h57SNZIHzWTibU1VfIGp5z3Xx8dPtv4yT5uGhiH7P5uvJRR2jkrvHafRxR7bTANkvfpg=="
+    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true
+    },
+    "node_modules/earcut": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
+      "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug=="
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
@@ -6534,6 +7290,14 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/expression-eval": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/expression-eval/-/expression-eval-2.1.0.tgz",
+      "integrity": "sha512-FUJO/Akvl/JOWkvlqZaqbkhsEWlCJWDeZG4tzX96UH68D9FeRgYgtb55C2qtqbORC0Q6x5419EDjWu4IT9kQfg==",
+      "dependencies": {
+        "jsep": "^0.3.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -6766,6 +7530,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/find-root": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
@@ -6795,6 +7570,11 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
+    },
+    "node_modules/flatbuffers": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.12.0.tgz",
+      "integrity": "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ=="
     },
     "node_modules/flatted": {
       "version": "3.2.4",
@@ -6962,6 +7742,11 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/geojson-vt": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
+      "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -7063,6 +7848,11 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "node_modules/gl-matrix": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.3.0.tgz",
+      "integrity": "sha512-COb7LDz+SXaHtl/h4LeaFcNdJdAQSDeVqjiIihSXNrkWObZLhDI4hIkZC11Aeqp7bcE72clzB0BnDXr2SmslRA=="
+    },
     "node_modules/glob": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
@@ -7146,6 +7936,29 @@
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
       "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+    },
+    "node_modules/grid-index": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
+      "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA=="
+    },
+    "node_modules/h3-js": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/h3-js/-/h3-js-3.7.2.tgz",
+      "integrity": "sha512-LPjlHSwB9zQZrMqKloCZmmmt3yZzIK7nqPcXqwU93zT3TtYG6jP4tZBzAPouxut7lLjdFbMQ75wRBiKfpsnY7w==",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=3",
+        "yarn": ">=1.3.0"
+      }
+    },
+    "node_modules/hammerjs": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
+      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE=",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/har-schema": {
       "version": "2.0.0",
@@ -7615,6 +8428,11 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
     },
     "node_modules/invariant": {
       "version": "2.2.4",
@@ -9936,6 +10754,14 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/jsep": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-0.3.5.tgz",
+      "integrity": "sha512-AoRLBDc6JNnKjNcmonituEABS5bcfqDhQAWWXNTFrqu6nVXBpBAGfcoTGZMFlIrh9FjmE1CQyX9CTNwZrXMMDA==",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -9945,6 +10771,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha1-QRY7UENsdz2CQk28IO1w23YEuNc=",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/json-parse-better-errors": {
@@ -10035,6 +10869,11 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/kdbush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
+      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew=="
     },
     "node_modules/kleur": {
       "version": "3.0.3",
@@ -10334,6 +11173,11 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -10530,6 +11374,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/long": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -10590,6 +11442,49 @@
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
+    },
+    "node_modules/mapbox-gl": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-2.6.1.tgz",
+      "integrity": "sha512-faGbSZfcFuZ4GWwkWnJrRD3oICZAt/mVKnGuOmeBobCj9onfTRz270qSoOXeRBKd3po5VA2cCPI91YwA8DsAoQ==",
+      "dependencies": {
+        "@mapbox/geojson-rewind": "^0.5.1",
+        "@mapbox/geojson-types": "^1.0.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^2.0.0",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^2.0.2",
+        "@mapbox/unitbezier": "^0.0.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^2.2.3",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.3.0",
+        "grid-index": "^1.1.0",
+        "minimist": "^1.2.5",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.2.1",
+        "potpack": "^1.0.1",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "supercluster": "^7.1.4",
+        "tinyqueue": "^2.0.3",
+        "vt-pbf": "^3.1.3"
+      }
+    },
+    "node_modules/mapbox-gl/node_modules/@mapbox/tiny-sdf": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.4.tgz",
+      "integrity": "sha512-CBtL2rhZiYmdIryksp0zh4Mmx54iClYfNb0mpYeHrZnq4z84lVjre7LBWGPEjWspEn6AiF0lxC1HaZDye89m3g=="
+    },
+    "node_modules/math.gl": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/math.gl/-/math.gl-3.5.6.tgz",
+      "integrity": "sha512-+IzdFaQk46iYU85XObRNqnb5NUQon+rWDPnCoEIOKOKdykr2gJ15BcVjEs0ZvH4EDv5K/JVmLkWzY/6DCEx2Fw==",
+      "dependencies": {
+        "@math.gl/core": "3.5.6"
+      }
     },
     "node_modules/md5.js": {
       "version": "1.3.5",
@@ -10720,10 +11615,28 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
+    "node_modules/mjolnir.js": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mjolnir.js/-/mjolnir.js-2.6.0.tgz",
+      "integrity": "sha512-rGA7+BJKvXI0ypxQD/+rQE/sW26kmc8UIZWhmQrjhwCf/zvhbcBlsu2vPB6w0Kv/rVnVFEONTSQqC0vFEpQvIA==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "hammerjs": "^2.0.8"
+      },
+      "engines": {
+        "node": ">= 4",
+        "npm": ">= 3"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E="
     },
     "node_modules/nanoid": {
       "version": "3.1.30",
@@ -11349,6 +12262,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/pad-left": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pad-left/-/pad-left-2.1.0.tgz",
+      "integrity": "sha1-FuajstRKjhOMsIOMx8tAOk/J6ZQ=",
+      "dependencies": {
+        "repeat-string": "^1.5.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -11452,6 +12376,18 @@
       "dev": true,
       "dependencies": {
         "through": "~2.3"
+      }
+    },
+    "node_modules/pbf": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
+      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
+      "dependencies": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
       }
     },
     "node_modules/pbkdf2": {
@@ -11592,6 +12528,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ=="
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -11670,6 +12611,15 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "node_modules/probe.gl": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/probe.gl/-/probe.gl-3.4.1.tgz",
+      "integrity": "sha512-k/6YoZr6cBwnFpQLs/s4yZ8cCxapQzRrxl16EQg1b2wYXLlerDJ4PkNoQ3YDN9yu3Jcipipr+Avy1GRpyBF6ZA==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@probe.gl/stats": "3.4.1"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -11709,6 +12659,11 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.8.1"
       }
+    },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
     },
     "node_modules/proxy-from-env": {
       "version": "1.0.0",
@@ -11827,6 +12782,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
     },
     "node_modules/ramda": {
       "version": "0.27.1",
@@ -11953,6 +12913,28 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-map-gl": {
+      "version": "6.1.17",
+      "resolved": "https://registry.npmjs.org/react-map-gl/-/react-map-gl-6.1.17.tgz",
+      "integrity": "sha512-SKuMtvs7aQpHMJehf/GzUQnEhPWRIypTX7X2wVXGME2RBKdY0PnC1YTiy8W3aA4uwcolPvCCYB+ki3xal51ZXQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@types/geojson": "^7946.0.7",
+        "@types/mapbox-gl": "^2.0.3",
+        "mapbox-gl": "^2.3.0",
+        "mjolnir.js": "^2.5.0",
+        "prop-types": "^15.7.2",
+        "resize-observer-polyfill": "^1.5.1",
+        "viewport-mercator-project": "^7.0.4"
+      },
+      "engines": {
+        "node": ">= 4",
+        "npm": ">= 3"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.8.3",
@@ -12116,6 +13098,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/reduce-flatten": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
@@ -12149,6 +13139,14 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/request-progress": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
@@ -12175,6 +13173,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "node_modules/resolve": {
       "version": "1.20.0",
@@ -12215,6 +13218,14 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
       }
     },
     "node_modules/resolve.exports": {
@@ -12295,6 +13306,11 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
     },
     "node_modules/rxjs": {
       "version": "7.4.0",
@@ -13058,6 +14074,14 @@
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.10.tgz",
       "integrity": "sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg=="
     },
+    "node_modules/supercluster": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.4.tgz",
+      "integrity": "sha512-GhKkRM1jMR6WUwGPw05fs66pOFWhf59lXq+Q3J3SxPvhNcmgOtLRV6aVQPMRsmXdpaeFJGivt+t7QXUPL3ff4g==",
+      "dependencies": {
+        "kdbush": "^3.0.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -13123,6 +14147,36 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/table-layout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
+      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
+      "dependencies": {
+        "array-back": "^4.0.1",
+        "deep-extend": "~0.6.0",
+        "typical": "^5.2.0",
+        "wordwrapjs": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/table-layout/node_modules/array-back": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table-layout/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/table/node_modules/ajv": {
@@ -13227,6 +14281,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/text-encoding-utf-8": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
+      "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -13266,6 +14325,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
       "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
+    },
+    "node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
     },
     "node_modules/tmp": {
       "version": "0.2.1",
@@ -13479,6 +14543,14 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -13672,10 +14744,28 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "node_modules/viewport-mercator-project": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/viewport-mercator-project/-/viewport-mercator-project-7.0.4.tgz",
+      "integrity": "sha512-0jzpL6pIMocCKWg1C3mqi/N4UPgZC3FzwghEm1H+XsUo8hNZAyJc3QR7YqC816ibOR8aWT5pCsV+gCu8/BMJgg==",
+      "dependencies": {
+        "@math.gl/web-mercator": "^3.5.5"
+      }
+    },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
+    },
+    "node_modules/vt-pbf": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
+      "integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
+      "dependencies": {
+        "@mapbox/point-geometry": "0.1.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "pbf": "^3.2.1"
+      }
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -13852,6 +14942,26 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wordwrapjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
+      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
+      "dependencies": {
+        "reduce-flatten": "^2.0.0",
+        "typical": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/wordwrapjs/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {
@@ -15145,6 +16255,121 @@
         }
       }
     },
+    "@deck.gl/aggregation-layers": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-8.6.4.tgz",
+      "integrity": "sha512-tcHaY6wyFtfggqVd0jWJSQyvSq4aToDJDwVLEb6ki80sWWsgNw5+eM51yhAsCzY+/ce74dI7Ou7sAtrGLON+xA==",
+      "requires": {
+        "@luma.gl/shadertools": "^8.5.10",
+        "@math.gl/web-mercator": "^3.5.4",
+        "d3-hexbin": "^0.2.1"
+      }
+    },
+    "@deck.gl/carto": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/carto/-/carto-8.6.4.tgz",
+      "integrity": "sha512-vvAVhcEU6LIYlqc4kKGwxlHGKiDSAq8AXOstfTnUHWt2+fYfseFb+P+h+GubBxqyoeRzmeTviZQ76wSeUqcXiw==",
+      "requires": {
+        "@loaders.gl/loader-utils": "^3.0.8",
+        "@loaders.gl/mvt": "^3.0.8",
+        "@loaders.gl/tiles": "^3.0.8",
+        "@math.gl/web-mercator": "^3.5.4",
+        "cartocolor": "^4.0.2",
+        "d3-scale": "^3.2.3"
+      }
+    },
+    "@deck.gl/core": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-8.6.4.tgz",
+      "integrity": "sha512-veSW3VSOsm+mYzWIoqn6GZlRzADy2uX2xX4vOGZ06dCdSTrF6LqcyINsEftcqbpznME0ugpsTVIXj3P15LESQA==",
+      "requires": {
+        "@loaders.gl/core": "^3.0.8",
+        "@loaders.gl/images": "^3.0.8",
+        "@luma.gl/core": "^8.5.10",
+        "@math.gl/web-mercator": "^3.5.4",
+        "gl-matrix": "^3.0.0",
+        "math.gl": "^3.5.4",
+        "mjolnir.js": "^2.5.0",
+        "probe.gl": "^3.4.0"
+      }
+    },
+    "@deck.gl/extensions": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-8.6.4.tgz",
+      "integrity": "sha512-sYT9lcuVWmnnmXpgjNqtRPYmVq94+aMiW7FgQNN0KkNKYFlDEyjy5CrrWlWosS2dVDQuS2WRPQ6Hm12VRvCsyQ==",
+      "requires": {
+        "@luma.gl/shadertools": "^8.5.10"
+      }
+    },
+    "@deck.gl/geo-layers": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-8.6.4.tgz",
+      "integrity": "sha512-NNEkaBy9YdCq31eG6rYgz6vfmvnP1/52oqlDAHveAs3DTchLXOszvh8tD17mAp1ox3Nc4aewW6EopXbDChpw4Q==",
+      "requires": {
+        "@loaders.gl/3d-tiles": "^3.0.8",
+        "@loaders.gl/gis": "^3.0.8",
+        "@loaders.gl/loader-utils": "^3.0.8",
+        "@loaders.gl/mvt": "^3.0.8",
+        "@loaders.gl/terrain": "^3.0.8",
+        "@loaders.gl/tiles": "^3.0.8",
+        "@luma.gl/experimental": "^8.5.10",
+        "@math.gl/culling": "^3.5.4",
+        "@math.gl/web-mercator": "^3.5.4",
+        "h3-js": "^3.6.0",
+        "long": "^3.2.0",
+        "math.gl": "^3.5.4"
+      }
+    },
+    "@deck.gl/google-maps": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/google-maps/-/google-maps-8.6.4.tgz",
+      "integrity": "sha512-D9h6oa4E6Yqq9eZoTz7PZXL8vFuNhjVF3sT0Onf6F/f+HrMXzWkVUNBX0Enn1tYk0LOOyqs0qeD/eCJihbPW0Q==",
+      "requires": {}
+    },
+    "@deck.gl/json": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/json/-/json-8.6.4.tgz",
+      "integrity": "sha512-VV5hBxjezkmS7mpfpxPUI5j00KfVf987K4jZUjHraoppdaKL1Rup+Lfi8wF8oSHovnufiu7xvz+FeZZOdp3u+w==",
+      "requires": {
+        "d3-dsv": "^1.0.8",
+        "expression-eval": "^2.0.0"
+      }
+    },
+    "@deck.gl/layers": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-8.6.4.tgz",
+      "integrity": "sha512-G2L9r6O3NsmiIidFrqU5YUBZWnwnfOf5GVqBw6KOj9+b0HTPNLJ6xuswzGnjmf4fILgknOXtLm6IrLjLNoCCDw==",
+      "requires": {
+        "@loaders.gl/images": "^3.0.8",
+        "@mapbox/tiny-sdf": "^1.1.0",
+        "@math.gl/polygon": "^3.5.4",
+        "earcut": "^2.0.6"
+      }
+    },
+    "@deck.gl/mapbox": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-8.6.4.tgz",
+      "integrity": "sha512-HD8pFW/9SMU0Idj/iilAFkwzko62UpVCN/UFixZ8wEU7+1zjxJVqP+uxZVUWpHJ2MgREp47FNlVTwdbFijMVLw==",
+      "requires": {}
+    },
+    "@deck.gl/mesh-layers": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-8.6.4.tgz",
+      "integrity": "sha512-WoJZR02PF5Ypd3X2c7vaF3rMHWcBVxdcnQ+SDFunebd+n+5H8zKJqxm0F+KMhSN7OhOW/K6NeT5ieMcDKkxniQ==",
+      "requires": {
+        "@loaders.gl/gltf": "^3.0.8",
+        "@luma.gl/experimental": "^8.5.10",
+        "@luma.gl/shadertools": "^8.5.10"
+      }
+    },
+    "@deck.gl/react": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-8.6.4.tgz",
+      "integrity": "sha512-k1S5Cpv5DdZyNa9miwbThyZJATAXTt9Ism6w1bGRa2LsgjUXUCmNhlCEdqPhYrRYYltg8x35WV8xa0UrafUqvA==",
+      "requires": {
+        "prop-types": "^15.6.0"
+      }
+    },
     "@emotion/babel-plugin": {
       "version": "11.3.0",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.3.0.tgz",
@@ -15905,6 +17130,331 @@
         }
       }
     },
+    "@loaders.gl/3d-tiles": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-3.0.13.tgz",
+      "integrity": "sha512-irR5IybohU7vFg6gSdmrtOdMokFCOzAWUJRdy/K42qssbHVhZlB8EO0Y1P+JhYuBHvtskNhHfM9IBTJbjgfWBw==",
+      "requires": {
+        "@loaders.gl/core": "3.0.13",
+        "@loaders.gl/draco": "3.0.13",
+        "@loaders.gl/gltf": "3.0.13",
+        "@loaders.gl/loader-utils": "3.0.13",
+        "@loaders.gl/math": "3.0.13",
+        "@loaders.gl/tiles": "3.0.13",
+        "@math.gl/core": "^3.5.1",
+        "@math.gl/geospatial": "^3.5.1"
+      }
+    },
+    "@loaders.gl/core": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-3.0.13.tgz",
+      "integrity": "sha512-Bi+VeITyRJtQLLx9YARpb4JzFkhXmKDiS2JVxdg5mn4i1QrzrLM0hPbtb4H6sNJ9S0WhFe3ikrXenGo/DL/aNw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "@loaders.gl/loader-utils": "3.0.13",
+        "@loaders.gl/worker-utils": "3.0.13",
+        "probe.gl": "^3.4.0"
+      }
+    },
+    "@loaders.gl/draco": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-3.0.13.tgz",
+      "integrity": "sha512-M9RCQHtqpAB1PK3HvXR2LJqBVhIdbndUie3lrWMGP4NFDGnDnDlTk7Kk/QEbgpidafdEbUiJEU/4/uEzYFA4Kw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "@loaders.gl/loader-utils": "3.0.13",
+        "@loaders.gl/schema": "3.0.13",
+        "@loaders.gl/worker-utils": "3.0.13",
+        "draco3d": "1.4.1"
+      }
+    },
+    "@loaders.gl/gis": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-3.0.13.tgz",
+      "integrity": "sha512-pftgUaKJ65gFwNyi+a2NGwjW8M5FlLZYnhKHjQ5/lNMYsodwSxp7HrJR5RKON+x6P7gaxjBgoCMDrAgWKNCDHQ==",
+      "requires": {
+        "@loaders.gl/loader-utils": "3.0.13",
+        "@loaders.gl/schema": "3.0.13",
+        "@mapbox/vector-tile": "^1.3.1",
+        "pbf": "^3.2.1"
+      }
+    },
+    "@loaders.gl/gltf": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-3.0.13.tgz",
+      "integrity": "sha512-QRzHFNxyz/f0QuyCvtreuOYr4cxfQvr141UWHQDPbgYgQpZlXa/JSP2/lTbXpaxd5LNLwHyNbDvpqv9u4bUwlw==",
+      "requires": {
+        "@loaders.gl/core": "3.0.13",
+        "@loaders.gl/draco": "3.0.13",
+        "@loaders.gl/images": "3.0.13",
+        "@loaders.gl/loader-utils": "3.0.13"
+      }
+    },
+    "@loaders.gl/images": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-3.0.13.tgz",
+      "integrity": "sha512-w4I80tUoVg7Df3OWnxbjZWgGEpf1pLqbxGC8j8lhB3na8n5CnEllt6iN94dnwawDlfDX9wTHXNNaCTIguYsv0Q==",
+      "requires": {
+        "@loaders.gl/loader-utils": "3.0.13"
+      }
+    },
+    "@loaders.gl/loader-utils": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-3.0.13.tgz",
+      "integrity": "sha512-tVDmytWaO1XHBV9F5UEQd55vAdnVDZhK2nUKY5oBfDlo1mG5PhXWOj2Za+yV4btMC86PWXYhLiUUgy+9vABPOw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "@loaders.gl/worker-utils": "3.0.13",
+        "@probe.gl/stats": "^3.4.0"
+      }
+    },
+    "@loaders.gl/math": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-3.0.13.tgz",
+      "integrity": "sha512-FMqJrOgO6IYxSW6ZhHpLKCLeP/1f4ASFZzo6J9CdON1MHv4YJ8jc1hDlDaiRDnOEl6ANCHvuSSVjUt9ML/XXgw==",
+      "requires": {
+        "@loaders.gl/images": "3.0.13",
+        "@loaders.gl/loader-utils": "3.0.13",
+        "@math.gl/core": "^3.5.1"
+      }
+    },
+    "@loaders.gl/mvt": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-3.0.13.tgz",
+      "integrity": "sha512-bo7ObDohK7sBlk4Y1WUjg8X2HQ6O9UaxhUmkJruceCtRpy1h7lqOEtxfwdFHXPWGCEUz27zhkk2dNtV8HffAbg==",
+      "requires": {
+        "@loaders.gl/gis": "3.0.13",
+        "@loaders.gl/loader-utils": "3.0.13",
+        "@math.gl/polygon": "^3.5.1",
+        "pbf": "^3.2.1"
+      }
+    },
+    "@loaders.gl/schema": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-3.0.13.tgz",
+      "integrity": "sha512-w6jPTnaSE/d5EfIKSVNRGFxUb56EiJrbKBUbZ6OgRkBlDlmSbLvRoaH/Jz5TT8ewK7DF6pumMqTXJ/0n0SZ5Pw==",
+      "requires": {
+        "@types/geojson": "^7946.0.7",
+        "apache-arrow": "^4.0.0",
+        "d3-dsv": "^1.2.0"
+      }
+    },
+    "@loaders.gl/terrain": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-3.0.13.tgz",
+      "integrity": "sha512-trUnxKFWGuHonIrQy4DvNjtRZZ+qgymS9xqKe3iZ7wqu9Ho/7ZbdnPzt75vIM1QQiDHSNiccBsq2Nr8g1BDuXg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "@loaders.gl/loader-utils": "3.0.13",
+        "@loaders.gl/schema": "3.0.13",
+        "@mapbox/martini": "^0.2.0"
+      }
+    },
+    "@loaders.gl/tiles": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-3.0.13.tgz",
+      "integrity": "sha512-mkbBIEXsVVEsVpkXkQrATG25Iw3lYaeHMVem4xCpCHQHV5d8cFyLnXBzWi/cWRzfEk+dAMT7g+LkxH39rG43og==",
+      "requires": {
+        "@loaders.gl/core": "3.0.13",
+        "@loaders.gl/loader-utils": "3.0.13",
+        "@loaders.gl/math": "3.0.13",
+        "@math.gl/core": "^3.5.1",
+        "@math.gl/culling": "^3.5.1",
+        "@math.gl/geospatial": "^3.5.1",
+        "@math.gl/web-mercator": "^3.5.1",
+        "@probe.gl/stats": "^3.4.0"
+      }
+    },
+    "@loaders.gl/worker-utils": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-3.0.13.tgz",
+      "integrity": "sha512-QB4jZumKGsouJprPzNKnKXTXMLf89afBwmi4Rnnw4SVj49olPiAGh4FZjf00GHFHKZlvAj8LB5rfqwd+Te6IVA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1"
+      }
+    },
+    "@luma.gl/constants": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-8.5.10.tgz",
+      "integrity": "sha512-0OZnNbb8hF+ogr/Exr5KFEnSMQdCgjrbO2ZYeNIGO0UVMTu4oTSLfRcBxKUs1NzxG5RogyV8dL6ETQbkP5VAZw=="
+    },
+    "@luma.gl/core": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-8.5.10.tgz",
+      "integrity": "sha512-NzzMnSgzPta3gMu8vSM/kWiY09HypHRXt4zw/xFX4geLeX4iXm7Jnm+eeaNpc/QH/yJ51+4bpvZml0P5NIukfQ==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "@luma.gl/constants": "8.5.10",
+        "@luma.gl/engine": "8.5.10",
+        "@luma.gl/gltools": "8.5.10",
+        "@luma.gl/shadertools": "8.5.10",
+        "@luma.gl/webgl": "8.5.10"
+      }
+    },
+    "@luma.gl/engine": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-8.5.10.tgz",
+      "integrity": "sha512-W3cPlabMl1g6dfAio4yGD9GohoMULXqsBm9P9WOh0KypQBw5pFlE2C/njY43YhfvnpMPDMUjjraYrEXa1fhaig==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "@luma.gl/constants": "8.5.10",
+        "@luma.gl/gltools": "8.5.10",
+        "@luma.gl/shadertools": "8.5.10",
+        "@luma.gl/webgl": "8.5.10",
+        "@math.gl/core": "^3.5.0",
+        "probe.gl": "^3.4.0"
+      }
+    },
+    "@luma.gl/experimental": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@luma.gl/experimental/-/experimental-8.5.10.tgz",
+      "integrity": "sha512-1Ldq2DEor9qWHoRetcAz4BID1pwp+5x67F2mfe2UtjEpDY0Modi7t8C94PR8cviyjRIu3DErxX7o8HxJ4JXxpQ==",
+      "requires": {
+        "@luma.gl/constants": "8.5.10",
+        "@math.gl/core": "^3.5.0",
+        "earcut": "^2.0.6"
+      }
+    },
+    "@luma.gl/gltools": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@luma.gl/gltools/-/gltools-8.5.10.tgz",
+      "integrity": "sha512-XQFocLXvSYfkW2xL1I50nYrPwgyt1jvmzmood3RQBQMiBcgU1JFW2w4tU+V/C5QXcAWWVzm8aIBkuQsCo34zrQ==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "@luma.gl/constants": "8.5.10",
+        "probe.gl": "^3.4.0"
+      }
+    },
+    "@luma.gl/shadertools": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-8.5.10.tgz",
+      "integrity": "sha512-Va/e7fHFI7ZWu03obtNlXN7noIUF1u9U3Pm6PVqeVi3Z24yWl/pFbb5/O1gn66LQZF6fpwoLGN7m4NGk2YyHyA==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "@math.gl/core": "^3.5.0"
+      }
+    },
+    "@luma.gl/webgl": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-8.5.10.tgz",
+      "integrity": "sha512-8cCJ6aoKmVKvrYoPC6G1jHqMsfTGyn50YMmRkrk2Q79nBe531LZr+6EYXlqx2+AR9obKwTnhTPlxjKg5gR4rYg==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "@luma.gl/constants": "8.5.10",
+        "@luma.gl/gltools": "8.5.10",
+        "probe.gl": "^3.4.0"
+      }
+    },
+    "@mapbox/geojson-rewind": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.1.tgz",
+      "integrity": "sha512-eL7fMmfTBKjrb+VFHXCGv9Ot0zc3C0U+CwXo1IrP+EPwDczLoXv34Tgq3y+2mPSFNVUXgU42ILWJTC7145KPTA==",
+      "requires": {
+        "get-stream": "^6.0.1",
+        "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
+        }
+      }
+    },
+    "@mapbox/geojson-types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
+      "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw=="
+    },
+    "@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ="
+    },
+    "@mapbox/mapbox-gl-supported": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-2.0.1.tgz",
+      "integrity": "sha512-HP6XvfNIzfoMVfyGjBckjiAOQK9WfX0ywdLubuPMPv+Vqf5fj0uCbgBQYpiqcWZT6cbyyRnTSXDheT1ugvF6UQ=="
+    },
+    "@mapbox/martini": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/martini/-/martini-0.2.0.tgz",
+      "integrity": "sha512-7hFhtkb0KTLEls+TRw/rWayq5EeHtTaErgm/NskVoXmtgAQu/9D299aeyj6mzAR/6XUnYRp2lU+4IcrYRFjVsQ=="
+    },
+    "@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
+    },
+    "@mapbox/tiny-sdf": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
+      "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw=="
+    },
+    "@mapbox/unitbezier": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
+      "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4="
+    },
+    "@mapbox/vector-tile": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "requires": {
+        "@mapbox/point-geometry": "~0.1.0"
+      }
+    },
+    "@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="
+    },
+    "@math.gl/core": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-3.5.6.tgz",
+      "integrity": "sha512-UGCKtJUBA9MBswclK6l8DuZqLcEnqlSfI57WzSDUB/Nki4tHfmdImJyhp8ky9W4cIahV1YLMhHRK1oRpLeC1sw==",
+      "requires": {
+        "@babel/runtime": "^7.12.0",
+        "gl-matrix": "~3.3.0"
+      }
+    },
+    "@math.gl/culling": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/@math.gl/culling/-/culling-3.5.6.tgz",
+      "integrity": "sha512-Sustyo3XRaGVeUAzKk9kzoWErfNUzi+YFsmLe00r4qLbzXPg0Z7uLGX6zloEELILgqOZMOuAhadfmWVMsbq8ZA==",
+      "requires": {
+        "@babel/runtime": "^7.12.0",
+        "@math.gl/core": "3.5.6",
+        "gl-matrix": "~3.3.0"
+      }
+    },
+    "@math.gl/geospatial": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/@math.gl/geospatial/-/geospatial-3.5.6.tgz",
+      "integrity": "sha512-pYdnVeqbR5ybvUl+vOn1Ybj3BEwXk44vuU+VxE/GFKlM9M2oQlOisdJ8v6lyUDu7mEx6t5xsu8VUwMz1PymKLQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.0",
+        "@math.gl/core": "3.5.6",
+        "gl-matrix": "~3.3.0"
+      }
+    },
+    "@math.gl/polygon": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-3.5.6.tgz",
+      "integrity": "sha512-CUGPmD8Y9elPRsb4+wG0nuElbEYcTK+Azks96M9zleMaOACUDqUY6D4rDtqpyEIeqcun85Aq+7eV/rjVMahWgA==",
+      "requires": {
+        "@math.gl/core": "3.5.6"
+      }
+    },
+    "@math.gl/web-mercator": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.5.6.tgz",
+      "integrity": "sha512-siWHLJGp9o8fDEM1t0Rby+JXftl6il0z3927liWGzkHqFftXPHY858ShPy45ThDU8q5lyCftg8aVgrv4nfD+Zw==",
+      "requires": {
+        "@babel/runtime": "^7.12.0",
+        "gl-matrix": "~3.3.0"
+      }
+    },
     "@napi-rs/triples": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@napi-rs/triples/-/triples-1.0.3.tgz",
@@ -16133,6 +17683,14 @@
       "version": "2.10.2",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.10.2.tgz",
       "integrity": "sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ=="
+    },
+    "@probe.gl/stats": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-3.4.1.tgz",
+      "integrity": "sha512-1Ol5cH8MQqIrGNgU4NCBj2cw1qiXYfHP1QCFX+u/xyrvgwLkPrOGkdSYMzw4VKTjJzNae4i7urOTf2m2hduZzQ==",
+      "requires": {
+        "@babel/runtime": "^7.0.0"
+      }
     },
     "@reach/alert": {
       "version": "0.13.2",
@@ -16426,6 +17984,16 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/flatbuffers": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@types/flatbuffers/-/flatbuffers-1.10.0.tgz",
+      "integrity": "sha512-7btbphLrKvo5yl/5CC2OCxUSMx1wV1wvGT1qDXkSt7yi00/YW7E8k6qzXqJHsp+WU0eoG7r6MTQQXI9lIvd0qA=="
+    },
+    "@types/geojson": {
+      "version": "7946.0.8",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
+      "integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA=="
+    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -16492,6 +18060,14 @@
       "integrity": "sha512-RY/8IaVENjG19rxTZu9Nukqh0W2UrYgmBj5sdns4hWRZaV8PqR7wIKHFKzvOTjo4zVRV7sVI+yFhAJql12Kfqg==",
       "requires": {
         "@types/lodash": "*"
+      }
+    },
+    "@types/mapbox-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.4.2.tgz",
+      "integrity": "sha512-mKgjmhUN780YGy9ZEyJK0Sr9gMtERmTQimGsIa5WrBHPlBXdmjYfqtz8nSMI7hOnQFphcuSMyqQswaQESFLHsA==",
+      "requires": {
+        "@types/geojson": "*"
       }
     },
     "@types/node": {
@@ -16574,6 +18150,11 @@
       "requires": {
         "@types/jest": "*"
       }
+    },
+    "@types/text-encoding-utf-8": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
+      "integrity": "sha512-AQ6zewa0ucLJvtUi5HsErbOFKAcQfRLt9zFLlUOvcXBy2G36a+ZDpCHSGdzJVUD8aNURtIjh9aSjCStNMRCcRQ=="
     },
     "@types/warning": {
       "version": "3.0.0",
@@ -16835,6 +18416,23 @@
         "picomatch": "^2.0.4"
       }
     },
+    "apache-arrow": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-4.0.1.tgz",
+      "integrity": "sha512-DyF7GXCbSjsw4P5C8b+qW7OnJKa6w9mJI0mhV0+EfZbVZCmhfiF6ffqcnrI/kzBrRqn9hH/Ft9n5+m4DTbBJpg==",
+      "requires": {
+        "@types/flatbuffers": "^1.10.0",
+        "@types/node": "^14.14.37",
+        "@types/text-encoding-utf-8": "^1.0.1",
+        "command-line-args": "5.1.1",
+        "command-line-usage": "6.1.1",
+        "flatbuffers": "1.12.0",
+        "json-bignum": "^0.0.3",
+        "pad-left": "^2.1.0",
+        "text-encoding-utf-8": "^1.0.2",
+        "tslib": "^2.2.0"
+      }
+    },
     "arch": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
@@ -16874,6 +18472,11 @@
         "@babel/runtime": "^7.10.2",
         "@babel/runtime-corejs3": "^7.10.2"
       }
+    },
+    "array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
     },
     "array-includes": {
       "version": "3.1.4",
@@ -17419,6 +19022,14 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001280.tgz",
       "integrity": "sha512-kFXwYvHe5rix25uwueBxC569o53J6TpnGu0BEEn+6Lhl2vsnAumRFWEBhDft1fwyo6m1r4i+RqA4+163FpeFcA=="
     },
+    "cartocolor": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/cartocolor/-/cartocolor-4.0.2.tgz",
+      "integrity": "sha512-+Gh9mb6lFxsDOLQlBLPxAHCnWXlg2W8q3AcVwqRcy95TdBbcOU89Wrb6h2Hd/6Ww1Kc1pzXmUdpnWD+xeCG0dg==",
+      "requires": {
+        "colorbrewer": "1.0.0"
+      }
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -17573,6 +19184,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "colorbrewer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/colorbrewer/-/colorbrewer-1.0.0.tgz",
+      "integrity": "sha1-T5czO5abp2Ejgr5LwzlLNB+0yKI="
+    },
     "colorette": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
@@ -17592,6 +19208,40 @@
       "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
+      }
+    },
+    "command-line-args": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
+      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
+      "requires": {
+        "array-back": "^3.0.1",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      }
+    },
+    "command-line-usage": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.1.tgz",
+      "integrity": "sha512-F59pEuAR9o1SF/bD0dQBDluhpT4jJQNWUHEuVBqpDmCUo6gPjCi+m9fCWnWZVR/oG6cMTUms4h+3NPl74wGXvA==",
+      "requires": {
+        "array-back": "^4.0.1",
+        "chalk": "^2.4.2",
+        "table-layout": "^1.0.1",
+        "typical": "^5.2.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+          "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg=="
+        },
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+        }
       }
     },
     "commander": {
@@ -17769,6 +19419,11 @@
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s="
     },
+    "csscolorparser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
+      "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs="
+    },
     "cssnano-preset-simple": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssnano-preset-simple/-/cssnano-preset-simple-3.0.0.tgz",
@@ -17925,6 +19580,90 @@
         }
       }
     },
+    "d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "requires": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+    },
+    "d3-dsv": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.2.0.tgz",
+      "integrity": "sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==",
+      "requires": {
+        "commander": "2",
+        "iconv-lite": "0.4",
+        "rw": "1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
+      }
+    },
+    "d3-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
+      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
+    },
+    "d3-hexbin": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/d3-hexbin/-/d3-hexbin-0.2.2.tgz",
+      "integrity": "sha1-nFg32s/UcasFM3qeke8Qv8T5iDE="
+    },
+    "d3-interpolate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "requires": {
+        "d3-color": "1 - 2"
+      }
+    },
+    "d3-scale": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
+      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
+      "requires": {
+        "d3-array": "^2.3.0",
+        "d3-format": "1 - 2",
+        "d3-interpolate": "1.2.0 - 2",
+        "d3-time": "^2.1.1",
+        "d3-time-format": "2 - 3"
+      }
+    },
+    "d3-time": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "requires": {
+        "d3-array": "2"
+      }
+    },
+    "d3-time-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "requires": {
+        "d3-time": "1 - 2"
+      }
+    },
     "damerau-levenshtein": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.7.tgz",
@@ -17976,6 +19715,24 @@
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
       "dev": true
     },
+    "deck.gl": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/deck.gl/-/deck.gl-8.6.4.tgz",
+      "integrity": "sha512-FC5EPMlhluthqK7knzhCOm1UVj3TDQp/f6IFkZd0Jdn1G0ECKq9MkmCJEeaOXcPWA8LBaTtIJSeSNetW5bKAOw==",
+      "requires": {
+        "@deck.gl/aggregation-layers": "8.6.4",
+        "@deck.gl/carto": "8.6.4",
+        "@deck.gl/core": "8.6.4",
+        "@deck.gl/extensions": "8.6.4",
+        "@deck.gl/geo-layers": "8.6.4",
+        "@deck.gl/google-maps": "8.6.4",
+        "@deck.gl/json": "8.6.4",
+        "@deck.gl/layers": "8.6.4",
+        "@deck.gl/mapbox": "8.6.4",
+        "@deck.gl/mesh-layers": "8.6.4",
+        "@deck.gl/react": "8.6.4"
+      }
+    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -17987,6 +19744,11 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.4",
@@ -18108,11 +19870,21 @@
         }
       }
     },
+    "draco3d": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.4.1.tgz",
+      "integrity": "sha512-9Rxonc70xiovBC+Bq1h57SNZIHzWTibU1VfIGp5z3Xx8dPtv4yT5uGhiH7P5uvJRR2jkrvHafRxR7bTANkvfpg=="
+    },
     "duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true
+    },
+    "earcut": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
+      "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -18924,6 +20696,14 @@
         }
       }
     },
+    "expression-eval": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/expression-eval/-/expression-eval-2.1.0.tgz",
+      "integrity": "sha512-FUJO/Akvl/JOWkvlqZaqbkhsEWlCJWDeZG4tzX96UH68D9FeRgYgtb55C2qtqbORC0Q6x5419EDjWu4IT9kQfg==",
+      "requires": {
+        "jsep": "^0.3.0"
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -19104,6 +20884,14 @@
         }
       }
     },
+    "find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "requires": {
+        "array-back": "^3.0.1"
+      }
+    },
     "find-root": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
@@ -19127,6 +20915,11 @@
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
       }
+    },
+    "flatbuffers": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.12.0.tgz",
+      "integrity": "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ=="
     },
     "flatted": {
       "version": "3.2.4",
@@ -19254,6 +21047,11 @@
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
     },
+    "geojson-vt": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
+      "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -19331,6 +21129,11 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "gl-matrix": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.3.0.tgz",
+      "integrity": "sha512-COb7LDz+SXaHtl/h4LeaFcNdJdAQSDeVqjiIihSXNrkWObZLhDI4hIkZC11Aeqp7bcE72clzB0BnDXr2SmslRA=="
+    },
     "glob": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
@@ -19390,6 +21193,21 @@
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
       "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+    },
+    "grid-index": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
+      "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA=="
+    },
+    "h3-js": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/h3-js/-/h3-js-3.7.2.tgz",
+      "integrity": "sha512-LPjlHSwB9zQZrMqKloCZmmmt3yZzIK7nqPcXqwU93zT3TtYG6jP4tZBzAPouxut7lLjdFbMQ75wRBiKfpsnY7w=="
+    },
+    "hammerjs": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
+      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
     },
     "har-schema": {
       "version": "2.0.0",
@@ -19716,6 +21534,11 @@
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       }
+    },
+    "internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
     },
     "invariant": {
       "version": "2.2.4",
@@ -21419,10 +23242,20 @@
         }
       }
     },
+    "jsep": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-0.3.5.tgz",
+      "integrity": "sha512-AoRLBDc6JNnKjNcmonituEABS5bcfqDhQAWWXNTFrqu6nVXBpBAGfcoTGZMFlIrh9FjmE1CQyX9CTNwZrXMMDA=="
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+    },
+    "json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha1-QRY7UENsdz2CQk28IO1w23YEuNc="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -21498,6 +23331,11 @@
         "array-includes": "^3.1.3",
         "object.assign": "^4.1.2"
       }
+    },
+    "kdbush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
+      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew=="
     },
     "kleur": {
       "version": "3.0.3",
@@ -21730,6 +23568,11 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -21879,6 +23722,11 @@
         }
       }
     },
+    "long": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -21924,6 +23772,51 @@
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
+    },
+    "mapbox-gl": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-2.6.1.tgz",
+      "integrity": "sha512-faGbSZfcFuZ4GWwkWnJrRD3oICZAt/mVKnGuOmeBobCj9onfTRz270qSoOXeRBKd3po5VA2cCPI91YwA8DsAoQ==",
+      "requires": {
+        "@mapbox/geojson-rewind": "^0.5.1",
+        "@mapbox/geojson-types": "^1.0.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^2.0.0",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^2.0.2",
+        "@mapbox/unitbezier": "^0.0.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^2.2.3",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.3.0",
+        "grid-index": "^1.1.0",
+        "minimist": "^1.2.5",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.2.1",
+        "potpack": "^1.0.1",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "supercluster": "^7.1.4",
+        "tinyqueue": "^2.0.3",
+        "vt-pbf": "^3.1.3"
+      },
+      "dependencies": {
+        "@mapbox/tiny-sdf": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.4.tgz",
+          "integrity": "sha512-CBtL2rhZiYmdIryksp0zh4Mmx54iClYfNb0mpYeHrZnq4z84lVjre7LBWGPEjWspEn6AiF0lxC1HaZDye89m3g=="
+        }
+      }
+    },
+    "math.gl": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/math.gl/-/math.gl-3.5.6.tgz",
+      "integrity": "sha512-+IzdFaQk46iYU85XObRNqnb5NUQon+rWDPnCoEIOKOKdykr2gJ15BcVjEs0ZvH4EDv5K/JVmLkWzY/6DCEx2Fw==",
+      "requires": {
+        "@math.gl/core": "3.5.6"
+      }
     },
     "md5.js": {
       "version": "1.3.5",
@@ -22029,10 +23922,24 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
+    "mjolnir.js": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mjolnir.js/-/mjolnir.js-2.6.0.tgz",
+      "integrity": "sha512-rGA7+BJKvXI0ypxQD/+rQE/sW26kmc8UIZWhmQrjhwCf/zvhbcBlsu2vPB6w0Kv/rVnVFEONTSQqC0vFEpQvIA==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "hammerjs": "^2.0.8"
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E="
     },
     "nanoid": {
       "version": "3.1.30",
@@ -22490,6 +24397,14 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
+    "pad-left": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pad-left/-/pad-left-2.1.0.tgz",
+      "integrity": "sha1-FuajstRKjhOMsIOMx8tAOk/J6ZQ=",
+      "requires": {
+        "repeat-string": "^1.5.4"
+      }
+    },
     "pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -22572,6 +24487,15 @@
       "dev": true,
       "requires": {
         "through": "~2.3"
+      }
+    },
+    "pbf": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
+      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
+      "requires": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
       }
     },
     "pbkdf2": {
@@ -22680,6 +24604,11 @@
         }
       }
     },
+    "potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ=="
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -22733,6 +24662,15 @@
         }
       }
     },
+    "probe.gl": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/probe.gl/-/probe.gl-3.4.1.tgz",
+      "integrity": "sha512-k/6YoZr6cBwnFpQLs/s4yZ8cCxapQzRrxl16EQg1b2wYXLlerDJ4PkNoQ3YDN9yu3Jcipipr+Avy1GRpyBF6ZA==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "@probe.gl/stats": "3.4.1"
+      }
+    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -22763,6 +24701,11 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.8.1"
       }
+    },
+    "protocol-buffers-schema": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
     },
     "proxy-from-env": {
       "version": "1.0.0",
@@ -22850,6 +24793,11 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
+    },
+    "quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
     },
     "ramda": {
       "version": "0.27.1",
@@ -22953,6 +24901,21 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-map-gl": {
+      "version": "6.1.17",
+      "resolved": "https://registry.npmjs.org/react-map-gl/-/react-map-gl-6.1.17.tgz",
+      "integrity": "sha512-SKuMtvs7aQpHMJehf/GzUQnEhPWRIypTX7X2wVXGME2RBKdY0PnC1YTiy8W3aA4uwcolPvCCYB+ki3xal51ZXQ==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "@types/geojson": "^7946.0.7",
+        "@types/mapbox-gl": "^2.0.3",
+        "mapbox-gl": "^2.3.0",
+        "mjolnir.js": "^2.5.0",
+        "prop-types": "^15.7.2",
+        "resize-observer-polyfill": "^1.5.1",
+        "viewport-mercator-project": "^7.0.4"
+      }
     },
     "react-refresh": {
       "version": "0.8.3",
@@ -23067,6 +25030,11 @@
         "strip-indent": "^3.0.0"
       }
     },
+    "reduce-flatten": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w=="
+    },
     "regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
@@ -23088,6 +25056,11 @@
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
     },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
     "request-progress": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
@@ -23108,6 +25081,11 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
+    },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
       "version": "1.20.0",
@@ -23139,6 +25117,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+    },
+    "resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "requires": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
     },
     "resolve.exports": {
       "version": "1.1.0",
@@ -23188,6 +25174,11 @@
       "requires": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
     },
     "rxjs": {
       "version": "7.4.0",
@@ -23799,6 +25790,14 @@
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.10.tgz",
       "integrity": "sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg=="
     },
+    "supercluster": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.4.tgz",
+      "integrity": "sha512-GhKkRM1jMR6WUwGPw05fs66pOFWhf59lXq+Q3J3SxPvhNcmgOtLRV6aVQPMRsmXdpaeFJGivt+t7QXUPL3ff4g==",
+      "requires": {
+        "kdbush": "^3.0.0"
+      }
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -23908,6 +25907,29 @@
         }
       }
     },
+    "table-layout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
+      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
+      "requires": {
+        "array-back": "^4.0.1",
+        "deep-extend": "~0.6.0",
+        "typical": "^5.2.0",
+        "wordwrapjs": "^4.0.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+          "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg=="
+        },
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+        }
+      }
+    },
     "terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -23928,6 +25950,11 @@
         "glob": "^7.1.4",
         "minimatch": "^3.0.4"
       }
+    },
+    "text-encoding-utf-8": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
+      "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
     },
     "text-table": {
       "version": "0.2.0",
@@ -23965,6 +25992,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
       "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
+    },
+    "tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
     },
     "tmp": {
       "version": "0.2.1",
@@ -24130,6 +26162,11 @@
       "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
       "dev": true
     },
+    "typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
+    },
     "unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -24285,10 +26322,28 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "viewport-mercator-project": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/viewport-mercator-project/-/viewport-mercator-project-7.0.4.tgz",
+      "integrity": "sha512-0jzpL6pIMocCKWg1C3mqi/N4UPgZC3FzwghEm1H+XsUo8hNZAyJc3QR7YqC816ibOR8aWT5pCsV+gCu8/BMJgg==",
+      "requires": {
+        "@math.gl/web-mercator": "^3.5.5"
+      }
+    },
     "vm-browserify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
+    },
+    "vt-pbf": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
+      "integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
+      "requires": {
+        "@mapbox/point-geometry": "0.1.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "pbf": "^3.2.1"
+      }
     },
     "w3c-hr-time": {
       "version": "1.0.2",
@@ -24429,6 +26484,22 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
+    },
+    "wordwrapjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
+      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
+      "requires": {
+        "reduce-flatten": "^2.0.0",
+        "typical": "^5.2.0"
+      },
+      "dependencies": {
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+        }
+      }
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,13 @@
   "name": "next-chakra-boilerplate",
   "private": true,
   "version": "0.1.0",
-  "keywords": ["boilerplate", "nextjs", "chakra", "chakra-ui", "template"],
+  "keywords": [
+    "boilerplate",
+    "nextjs",
+    "chakra",
+    "chakra-ui",
+    "template"
+  ],
   "description": "A simple project boilerplate with Next.js, Chakra-UI, and variable code quality tools",
   "engines": {
     "node": ">=16.13.0"
@@ -27,10 +33,12 @@
     "@chakra-ui/theme-tools": "^1.1.2",
     "@emotion/react": "^11.5.0",
     "@emotion/styled": "^11.3.0",
+    "deck.gl": "^8.6.4",
     "framer-motion": "^4.1.17",
     "next": "latest",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "react-map-gl": "^6.1.17"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { Box } from "@chakra-ui/react";
+import DeckGL from "@deck.gl/react";
+import { StaticMap } from "react-map-gl";
+import {
+  CartoLayer,
+  setDefaultCredentials,
+  API_VERSIONS,
+  MAP_TYPES,
+} from "@deck.gl/carto";
+
+setDefaultCredentials({
+  apiVersion: API_VERSIONS.V2,
+  username: process.env.NEXT_PUBLIC_CARTO_USERNAME,
+  apiKey: process.env.NEXT_PUBLIC_CARTO_API_KEY,
+});
+
+export const Map = () => {
+  const INITIAL_VIEW_STATE = {
+    longitude: -73.986607,
+    latitude: 40.691869,
+    zoom: 13,
+    pitch: 0,
+    bearing: 0,
+  };
+
+  const [layers, setLayers] = useState([
+    new CartoLayer({
+      type: MAP_TYPES.QUERY,
+      id: "dcpNta",
+      data: `SELECT * FROM dcp_nta`,
+      getLineColor: [100, 100, 100, 255],
+      getFillColor: [0, 0, 0, 1],
+      lineWidthMinPixels: 3,
+      stroked: true,
+      pickable: true,
+    }),
+  ]);
+
+  return (
+    <Box h="100%" w="100%">
+      <DeckGL
+        initialViewState={INITIAL_VIEW_STATE}
+        controller={true}
+        layers={layers}
+      >
+        <StaticMap
+          mapboxApiAccessToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN}
+        />
+      </DeckGL>
+    </Box>
+  );
+};

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -1,0 +1,1 @@
+export * from "./Map";

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,54 +1,10 @@
-import {
-  Link as ChakraLink,
-  Text,
-  Code,
-  List,
-  ListIcon,
-  ListItem,
-} from "@chakra-ui/react";
-import { CheckCircleIcon, LinkIcon } from "@chakra-ui/icons";
-
-import { Hero } from "../components/Hero";
-import { Container } from "../components/Container";
-import { Main } from "../components/Main";
-import { Footer } from "../components/Footer";
+import { Box } from "@chakra-ui/react";
+import { Map } from "../components/Map";
 
 const Index = () => (
-  <Container>
-    <Hero title="Next & Chakra Boilerplate" />
-    <Main>
-      <Text>
-        Example repository of <Code>Next.js</Code> + <Code>chakra-ui</Code> +{" "}
-        <Code>typescript</Code>.
-      </Text>
-
-      <List spacing={3} my={0}>
-        <ListItem>
-          <ListIcon as={CheckCircleIcon} color="green.500" />
-          <ChakraLink
-            isExternal
-            href="https://chakra-ui.com"
-            flexGrow={1}
-            mr={4}
-          >
-            Chakra UI <LinkIcon />
-          </ChakraLink>
-        </ListItem>
-        <ListItem>
-          <ListIcon as={CheckCircleIcon} color="green.500" />
-          <ChakraLink isExternal href="https://nextjs.org" flexGrow={1} mr={2}>
-            Next.js <LinkIcon />
-          </ChakraLink>
-        </ListItem>
-      </List>
-    </Main>
-
-    {/* <DarkModeSwitch /> */}
-    <Footer>
-      <Text>Next ❤️ Chakra</Text>
-    </Footer>
-    {/* <CTA /> */}
-  </Container>
+  <Box h="800px" w="100%">
+    <Map />
+  </Box>
 );
 
 export default Index;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     "strict": true,
     "target": "esnext",
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "incremental": true
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
### Summary
Introduces DeckGL and connects it to Carto for an NTA Overlay. A basic DeckGL map with Mapbox basemap covers the entire screen. 

#### Tasks/Bug Numbers
 - Fixes AB#5718 
