### PR TITLE
5718 opentile basemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "next-chakra-boilerplate",
+  "name": "equity-tool",
   "private": true,
   "version": "0.1.0",
   "keywords": [
@@ -9,7 +9,7 @@
     "chakra-ui",
     "template"
   ],
-  "description": "A simple project boilerplate with Next.js, Chakra-UI, and variable code quality tools",
+  "description": "An interactive citywide equitable development tool for New York City, built by DCP Digital Services.",
   "engines": {
     "node": ">=16.13.0"
   },

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Box } from "@chakra-ui/react";
 import DeckGL from "@deck.gl/react";
 import { StaticMap } from "react-map-gl";
+import baseMap from "@data/basemap.json";
 import {
   CartoLayer,
   setDefaultCredentials,
@@ -46,6 +47,7 @@ export const Map = () => {
       >
         <StaticMap
           mapboxApiAccessToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN}
+          mapStyle={baseMap}
         />
       </DeckGL>
     </Box>

--- a/src/data/basemap.json
+++ b/src/data/basemap.json
@@ -1,0 +1,1768 @@
+{
+  "version": 8,
+  "name": "NYCPlanning Positron",
+  "metadata": {
+    "attribution": "Based on OpenMapTiles Positron style: https://github.com/openmaptiles/positron-gl-style"
+  },
+  "center": [-73.869324, 40.815888],
+  "zoom": 9.72,
+  "bearing": 0,
+  "pitch": 0,
+  "sources": {
+    "openmaptiles": {
+      "type": "vector",
+      "tiles":[
+         "https://tiles.planninglabs.nyc/data/v3/{z}/{x}/{y}.pbf"
+      ],
+      "name":"OpenMapTiles",
+      "format":"pbf",
+      "basename":"north-america_us-northeast.mbtiles",
+      "id":"openmaptiles",
+      "attribution":"<a href=\"http://www.openmaptiles.org/\" target=\"_blank\">&copy; OpenMapTiles</a> <a href=\"http://www.openstreetmap.org/about/\" target=\"_blank\">&copy; OpenStreetMap contributors</a>",
+      "center":[
+         -73.70104,
+         43.128005,
+         14
+      ],
+      "description":"Extract from https://openmaptiles.org",
+      "maxzoom":14,
+      "minzoom":0,
+      "pixel_scale":"256",
+      "version":"3.6.1",
+      "maskLevel":"5",
+      "bounds":[
+         -80.52632,
+         38.77178,
+         -66.87576,
+         47.48423
+      ],
+      "planettime":"1499040000000",
+      "vector_layers":[
+         {
+            "maxzoom":14,
+            "fields":{
+               "class":"String"
+            },
+            "minzoom":0,
+            "id":"water",
+            "description":""
+         },
+         {
+            "maxzoom":14,
+            "fields":{
+               "name:mt":"String",
+               "name:pt":"String",
+               "name:az":"String",
+               "name:ka":"String",
+               "name:rm":"String",
+               "name:ko":"String",
+               "name:kn":"String",
+               "name:ar":"String",
+               "name:cs":"String",
+               "name_de":"String",
+               "name:ro":"String",
+               "name:it":"String",
+               "name_int":"String",
+               "name:ru":"String",
+               "name:pl":"String",
+               "name:ca":"String",
+               "name:lv":"String",
+               "name:bg":"String",
+               "name:cy":"String",
+               "name:fi":"String",
+               "name:he":"String",
+               "name:da":"String",
+               "name:de":"String",
+               "name:tr":"String",
+               "name:fr":"String",
+               "name:mk":"String",
+               "name:nonlatin":"String",
+               "name:fy":"String",
+               "name:be":"String",
+               "name:zh":"String",
+               "name:sr":"String",
+               "name:sl":"String",
+               "name:nl":"String",
+               "name:ja":"String",
+               "name:lt":"String",
+               "name:no":"String",
+               "name:kk":"String",
+               "name:ko_rm":"String",
+               "name:ja_rm":"String",
+               "name:br":"String",
+               "name:bs":"String",
+               "name:lb":"String",
+               "name:la":"String",
+               "name:sk":"String",
+               "name:uk":"String",
+               "name:hy":"String",
+               "name:sv":"String",
+               "name_en":"String",
+               "name:hu":"String",
+               "name:hr":"String",
+               "class":"String",
+               "name:sq":"String",
+               "name:el":"String",
+               "name:ga":"String",
+               "name:en":"String",
+               "name":"String",
+               "name:gd":"String",
+               "name:ja_kana":"String",
+               "name:is":"String",
+               "name:th":"String",
+               "name:latin":"String",
+               "name:sr-Latn":"String",
+               "name:et":"String",
+               "name:es":"String"
+            },
+            "minzoom":0,
+            "id":"waterway",
+            "description":""
+         },
+         {
+            "maxzoom":14,
+            "fields":{
+               "class":"String",
+               "subclass":"String"
+            },
+            "minzoom":0,
+            "id":"landcover",
+            "description":""
+         },
+         {
+            "maxzoom":14,
+            "fields":{
+               "class":"String"
+            },
+            "minzoom":0,
+            "id":"landuse",
+            "description":""
+         },
+         {
+            "maxzoom":14,
+            "fields":{
+               "name:mt":"String",
+               "name:pt":"String",
+               "name:az":"String",
+               "name:ka":"String",
+               "name:rm":"String",
+               "name:ko":"String",
+               "name:kn":"String",
+               "name:ar":"String",
+               "name:cs":"String",
+               "rank":"Number",
+               "name_de":"String",
+               "name:ro":"String",
+               "name:it":"String",
+               "name_int":"String",
+               "name:lv":"String",
+               "name:pl":"String",
+               "name:de":"String",
+               "name:ca":"String",
+               "name:bg":"String",
+               "name:cy":"String",
+               "name:fi":"String",
+               "name:he":"String",
+               "name:da":"String",
+               "ele":"Number",
+               "name:tr":"String",
+               "name:fr":"String",
+               "name:mk":"String",
+               "name:nonlatin":"String",
+               "name:fy":"String",
+               "name:be":"String",
+               "name:zh":"String",
+               "name:sl":"String",
+               "name:nl":"String",
+               "name:ja":"String",
+               "name:lt":"String",
+               "name:no":"String",
+               "name:kk":"String",
+               "name:ko_rm":"String",
+               "name:ja_rm":"String",
+               "name:br":"String",
+               "name:bs":"String",
+               "name:lb":"String",
+               "name:la":"String",
+               "name:sk":"String",
+               "name:uk":"String",
+               "name:hy":"String",
+               "name:ru":"String",
+               "name:sv":"String",
+               "name_en":"String",
+               "name:hu":"String",
+               "name:hr":"String",
+               "name:sr":"String",
+               "name:sq":"String",
+               "name:el":"String",
+               "name:ga":"String",
+               "name:en":"String",
+               "name":"String",
+               "name:gd":"String",
+               "ele_ft":"Number",
+               "name:ja_kana":"String",
+               "name:is":"String",
+               "osm_id":"Number",
+               "name:th":"String",
+               "name:latin":"String",
+               "name:sr-Latn":"String",
+               "name:et":"String",
+               "name:es":"String"
+            },
+            "minzoom":0,
+            "id":"mountain_peak",
+            "description":""
+         },
+         {
+            "maxzoom":14,
+            "fields":{
+               "class":"String"
+            },
+            "minzoom":0,
+            "id":"park",
+            "description":""
+         },
+         {
+            "maxzoom":14,
+            "fields":{
+               "admin_level":"Number",
+               "disputed":"Number",
+               "maritime":"Number"
+            },
+            "minzoom":0,
+            "id":"boundary",
+            "description":""
+         },
+         {
+            "maxzoom":14,
+            "fields":{
+               "class":"String"
+            },
+            "minzoom":0,
+            "id":"aeroway",
+            "description":""
+         },
+         {
+            "maxzoom":14,
+            "fields":{
+               "brunnel":"String",
+               "ramp":"Number",
+               "class":"String",
+               "service":"String",
+               "oneway":"Number"
+            },
+            "minzoom":0,
+            "id":"transportation",
+            "description":""
+         },
+         {
+            "maxzoom":14,
+            "fields":{
+               "render_min_height":"Number",
+               "render_height":"Number"
+            },
+            "minzoom":0,
+            "id":"building",
+            "description":""
+         },
+         {
+            "maxzoom":14,
+            "fields":{
+               "name:mt":"String",
+               "name:pt":"String",
+               "name:az":"String",
+               "name:ka":"String",
+               "name:rm":"String",
+               "name:ko":"String",
+               "name:kn":"String",
+               "name:ar":"String",
+               "name:cs":"String",
+               "name_de":"String",
+               "name:ro":"String",
+               "name:it":"String",
+               "name_int":"String",
+               "name:ru":"String",
+               "name:pl":"String",
+               "name:ca":"String",
+               "name:lv":"String",
+               "name:bg":"String",
+               "name:cy":"String",
+               "name:fi":"String",
+               "name:he":"String",
+               "name:da":"String",
+               "name:de":"String",
+               "name:tr":"String",
+               "name:fr":"String",
+               "name:mk":"String",
+               "name:nonlatin":"String",
+               "name:fy":"String",
+               "name:be":"String",
+               "name:zh":"String",
+               "name:sr":"String",
+               "name:sl":"String",
+               "name:nl":"String",
+               "name:ja":"String",
+               "name:lt":"String",
+               "name:no":"String",
+               "name:kk":"String",
+               "name:ko_rm":"String",
+               "name:ja_rm":"String",
+               "name:br":"String",
+               "name:bs":"String",
+               "name:lb":"String",
+               "name:la":"String",
+               "name:sk":"String",
+               "name:uk":"String",
+               "name:hy":"String",
+               "name:sv":"String",
+               "name_en":"String",
+               "name:hu":"String",
+               "name:hr":"String",
+               "class":"String",
+               "name:sq":"String",
+               "name:el":"String",
+               "name:ga":"String",
+               "name:en":"String",
+               "name":"String",
+               "name:gd":"String",
+               "name:ja_kana":"String",
+               "name:is":"String",
+               "name:th":"String",
+               "name:latin":"String",
+               "name:sr-Latn":"String",
+               "name:et":"String",
+               "name:es":"String"
+            },
+            "minzoom":0,
+            "id":"water_name",
+            "description":""
+         },
+         {
+            "maxzoom":14,
+            "fields":{
+               "name:mt":"String",
+               "name:pt":"String",
+               "name:az":"String",
+               "name:ka":"String",
+               "name:rm":"String",
+               "name:ko":"String",
+               "name:kn":"String",
+               "name:ar":"String",
+               "name:cs":"String",
+               "name_de":"String",
+               "name:ro":"String",
+               "name:it":"String",
+               "name_int":"String",
+               "name:ru":"String",
+               "name:pl":"String",
+               "name:ca":"String",
+               "name:lv":"String",
+               "name:bg":"String",
+               "name:cy":"String",
+               "name:fi":"String",
+               "name:he":"String",
+               "name:da":"String",
+               "name:de":"String",
+               "name:tr":"String",
+               "name:fr":"String",
+               "name:mk":"String",
+               "name:nonlatin":"String",
+               "name:fy":"String",
+               "name:be":"String",
+               "name:zh":"String",
+               "name:sr":"String",
+               "name:sl":"String",
+               "name:nl":"String",
+               "name:ja":"String",
+               "name:lt":"String",
+               "name:no":"String",
+               "name:kk":"String",
+               "name:ko_rm":"String",
+               "name:ja_rm":"String",
+               "name:br":"String",
+               "name:bs":"String",
+               "name:lb":"String",
+               "name:la":"String",
+               "name:sk":"String",
+               "name:uk":"String",
+               "name:hy":"String",
+               "name:sv":"String",
+               "name_en":"String",
+               "name:hu":"String",
+               "name:hr":"String",
+               "class":"String",
+               "name:sq":"String",
+               "network":"String",
+               "name:el":"String",
+               "name:ga":"String",
+               "name:en":"String",
+               "name":"String",
+               "name:gd":"String",
+               "ref":"String",
+               "name:ja_kana":"String",
+               "ref_length":"Number",
+               "name:is":"String",
+               "name:th":"String",
+               "name:latin":"String",
+               "name:sr-Latn":"String",
+               "name:et":"String",
+               "name:es":"String"
+            },
+            "minzoom":0,
+            "id":"transportation_name",
+            "description":""
+         },
+         {
+            "maxzoom":14,
+            "fields":{
+               "name:mt":"String",
+               "name:pt":"String",
+               "name:az":"String",
+               "name:ka":"String",
+               "name:rm":"String",
+               "name:ko":"String",
+               "name:kn":"String",
+               "name:ar":"String",
+               "name:cs":"String",
+               "rank":"Number",
+               "name_de":"String",
+               "name:ro":"String",
+               "name:it":"String",
+               "name_int":"String",
+               "name:ru":"String",
+               "name:pl":"String",
+               "name:ca":"String",
+               "name:lv":"String",
+               "name:bg":"String",
+               "name:cy":"String",
+               "name:hr":"String",
+               "name:fi":"String",
+               "name:he":"String",
+               "name:da":"String",
+               "name:de":"String",
+               "name:tr":"String",
+               "name:fr":"String",
+               "name:mk":"String",
+               "name:nonlatin":"String",
+               "name:fy":"String",
+               "name:be":"String",
+               "name:zh":"String",
+               "name:sr":"String",
+               "name:sl":"String",
+               "name:nl":"String",
+               "name:ja":"String",
+               "name:ko_rm":"String",
+               "name:no":"String",
+               "name:kk":"String",
+               "capital":"Number",
+               "name:ja_rm":"String",
+               "name:br":"String",
+               "name:bs":"String",
+               "name:lb":"String",
+               "name:la":"String",
+               "name:sk":"String",
+               "name:uk":"String",
+               "name:hy":"String",
+               "name:sv":"String",
+               "name_en":"String",
+               "name:hu":"String",
+               "name:lt":"String",
+               "class":"String",
+               "name:sq":"String",
+               "name:el":"String",
+               "name:ga":"String",
+               "name:en":"String",
+               "name":"String",
+               "name:gd":"String",
+               "name:ja_kana":"String",
+               "name:is":"String",
+               "name:th":"String",
+               "name:latin":"String",
+               "name:sr-Latn":"String",
+               "name:et":"String",
+               "name:es":"String"
+            },
+            "minzoom":0,
+            "id":"place",
+            "description":""
+         },
+         {
+            "maxzoom":14,
+            "fields":{
+               "housenumber":"String"
+            },
+            "minzoom":0,
+            "id":"housenumber",
+            "description":""
+         },
+         {
+            "maxzoom":14,
+            "fields":{
+               "name:mt":"String",
+               "name:pt":"String",
+               "name:az":"String",
+               "name:ka":"String",
+               "name:rm":"String",
+               "name:ko":"String",
+               "name:kn":"String",
+               "name:ar":"String",
+               "name:cs":"String",
+               "rank":"Number",
+               "name_de":"String",
+               "name:ro":"String",
+               "name:it":"String",
+               "name_int":"String",
+               "name:ru":"String",
+               "name:pl":"String",
+               "name:ca":"String",
+               "name:lv":"String",
+               "name:bg":"String",
+               "name:cy":"String",
+               "name:fi":"String",
+               "name:he":"String",
+               "name:da":"String",
+               "subclass":"String",
+               "name:de":"String",
+               "name:tr":"String",
+               "name:fr":"String",
+               "name:mk":"String",
+               "name:nonlatin":"String",
+               "name:fy":"String",
+               "name:be":"String",
+               "name:zh":"String",
+               "name:sr":"String",
+               "name:sl":"String",
+               "name:nl":"String",
+               "name:ja":"String",
+               "name:lt":"String",
+               "name:no":"String",
+               "name:kk":"String",
+               "name:ko_rm":"String",
+               "name:ja_rm":"String",
+               "name:br":"String",
+               "name:bs":"String",
+               "name:lb":"String",
+               "name:la":"String",
+               "name:sk":"String",
+               "name:uk":"String",
+               "name:hy":"String",
+               "name:sv":"String",
+               "name_en":"String",
+               "name:hu":"String",
+               "name:hr":"String",
+               "class":"String",
+               "name:sq":"String",
+               "name:el":"String",
+               "name:ga":"String",
+               "name:en":"String",
+               "name":"String",
+               "name:gd":"String",
+               "name:ja_kana":"String",
+               "name:is":"String",
+               "name:th":"String",
+               "name:latin":"String",
+               "name:sr-Latn":"String",
+               "name:et":"String",
+               "name:es":"String"
+            },
+            "minzoom":0,
+            "id":"poi",
+            "description":""
+         },
+         {
+            "id":"omt_watermark",
+            "fields":{
+               "attribution":"String"
+            },
+            "minzoom":0,
+            "maxzoom":1
+         }
+      ],
+      "tilejson":"2.0.0"
+    }    
+  },
+  "glyphs": "https://tiles.planninglabs.nyc/fonts/{fontstack}/{range}.pbf",
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "paint": { "background-color": "rgb(242,243,240)" }
+    },
+    {
+      "id": "park",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "park",
+      "filter": ["==", "$type", "Polygon"],
+      "layout": { "visibility": "visible" },
+      "paint": { "fill-color": "rgb(230, 233, 229)" }
+    },
+    {
+      "id": "water",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "water",
+      "filter": ["==", "$type", "Polygon"],
+      "layout": { "visibility": "visible" },
+      "paint": { "fill-color": "rgb(194, 200, 202)", "fill-antialias": true }
+    },
+    {
+      "id": "landcover_ice_shelf",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "maxzoom": 8,
+      "filter": [
+        "all",
+        ["==", "$type", "Polygon"],
+        ["==", "subclass", "ice_shelf"]
+      ],
+      "layout": { "visibility": "visible" },
+      "paint": { "fill-color": "hsl(0, 0%, 98%)", "fill-opacity": 0.7 }
+    },
+    {
+      "id": "landcover_glacier",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "maxzoom": 8,
+      "filter": [
+        "all",
+        ["==", "$type", "Polygon"],
+        ["==", "subclass", "glacier"]
+      ],
+      "layout": { "visibility": "visible" },
+      "paint": {
+        "fill-color": "hsl(0, 0%, 98%)",
+        "fill-opacity": {
+          "base": 1,
+          "stops": [
+            [0, 1],
+            [8, 0.5]
+          ]
+        }
+      }
+    },
+    {
+      "id": "landuse_residential",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "maxzoom": 16,
+      "filter": [
+        "all",
+        ["==", "$type", "Polygon"],
+        ["==", "class", "residential"]
+      ],
+      "layout": { "visibility": "visible" },
+      "paint": {
+        "fill-color": "rgb(234, 234, 230)",
+        "fill-opacity": {
+          "base": 0.6,
+          "stops": [
+            [8, 0.8],
+            [9, 0.6]
+          ]
+        }
+      }
+    },
+    {
+      "id": "landcover_grass",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "minzoom": 10,
+      "filter": ["all", ["==", "$type", "Polygon"], ["==", "class", "grass"]],
+      "layout": { "visibility": "visible" },
+      "paint": {
+        "fill-color": "rgba(211, 230, 211, 1)",
+        "fill-opacity": {
+          "base": 1,
+          "stops": [
+            [8, 0],
+            [12, 1]
+          ]
+        }
+      }
+    },
+    {
+      "id": "landuse_cemetery",
+      "type": "fill",
+      "metadata": {},
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "filter": ["==", "class", "cemetery"],
+      "layout": { "visibility": "visible" },
+      "paint": { "fill-color": "rgba(211, 230, 211, 1)" }
+    },
+    {
+      "id": "waterway",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "filter": ["==", "$type", "LineString"],
+      "layout": { "visibility": "visible" },
+      "paint": { "line-color": "#bbccdd", "line-dasharray": [3, 3] }
+    },
+    {
+      "id": "water_name",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "water_name",
+      "filter": ["==", "$type", "LineString"],
+      "layout": {
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "symbol-placement": "line",
+        "text-rotation-alignment": "map",
+        "symbol-spacing": 500,
+        "text-font": ["Metropolis Medium Italic", "Noto Sans Italic"],
+        "text-size": 12
+      },
+      "paint": {
+        "text-color": "rgb(157,169,177)",
+        "text-halo-color": "rgb(242,243,240)",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "building",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "building",
+      "minzoom": 12,
+      "paint": {
+        "fill-color": "rgb(234, 234, 229)",
+        "fill-outline-color": "rgb(219, 219, 218)",
+        "fill-antialias": true
+      },
+      "filter": ["all"]
+    },
+    {
+      "id": "tunnel_motorway_casing",
+      "type": "line",
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 6,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["all", ["==", "brunnel", "tunnel"], ["==", "class", "motorway"]]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "miter",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgb(213, 213, 213)",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [5.8, 0],
+            [6, 3],
+            [20, 40]
+          ]
+        },
+        "line-opacity": 1
+      }
+    },
+    {
+      "id": "tunnel_motorway_inner",
+      "type": "line",
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 6,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["all", ["==", "brunnel", "tunnel"], ["==", "class", "motorway"]]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgb(234,234,234)",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [4, 2],
+            [6, 1.3],
+            [20, 30]
+          ]
+        }
+      }
+    },
+    {
+      "id": "aeroway-taxiway",
+      "type": "line",
+      "metadata": { "mapbox:group": "1444849345966.4436" },
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "minzoom": 12,
+      "filter": ["all", ["in", "class", "taxiway"]],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0, 0%, 88%)",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [13, 1.8],
+            [20, 20]
+          ]
+        },
+        "line-opacity": 1
+      }
+    },
+    {
+      "id": "aeroway-runway-casing",
+      "type": "line",
+      "metadata": { "mapbox:group": "1444849345966.4436" },
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "minzoom": 11,
+      "filter": ["all", ["in", "class", "runway"]],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0, 0%, 88%)",
+        "line-width": {
+          "base": 1.5,
+          "stops": [
+            [11, 6],
+            [17, 55]
+          ]
+        },
+        "line-opacity": 1
+      }
+    },
+    {
+      "id": "aeroway-area",
+      "type": "fill",
+      "metadata": { "mapbox:group": "1444849345966.4436" },
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "minzoom": 4,
+      "filter": [
+        "all",
+        ["==", "$type", "Polygon"],
+        ["in", "class", "runway", "taxiway"]
+      ],
+      "layout": { "visibility": "visible" },
+      "paint": {
+        "fill-opacity": {
+          "base": 1,
+          "stops": [
+            [13, 0],
+            [14, 1]
+          ]
+        },
+        "fill-color": "rgba(255, 255, 255, 1)"
+      }
+    },
+    {
+      "id": "aeroway-runway",
+      "type": "line",
+      "metadata": { "mapbox:group": "1444849345966.4436" },
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "minzoom": 11,
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        ["in", "class", "runway"],
+        ["==", "$type", "LineString"]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(255, 255, 255, 1)",
+        "line-width": {
+          "base": 1.5,
+          "stops": [
+            [11, 4],
+            [17, 50]
+          ]
+        },
+        "line-opacity": 1
+      }
+    },
+    {
+      "id": "highway_path",
+      "type": "line",
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": ["all", ["==", "$type", "LineString"], ["==", "class", "path"]],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgb(234, 234, 234)",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [13, 1],
+            [20, 10]
+          ]
+        },
+        "line-opacity": 0.9
+      }
+    },
+    {
+      "id": "highway_minor",
+      "type": "line",
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 8,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["in", "class", "minor", "service", "track"]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0, 0%, 88%)",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [13, 1.8],
+            [20, 20]
+          ]
+        },
+        "line-opacity": 0.9
+      }
+    },
+    {
+      "id": "highway_major_casing",
+      "type": "line",
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 11,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["in", "class", "primary", "secondary", "tertiary", "trunk"]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "miter",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgb(213, 213, 213)",
+        "line-dasharray": [12, 0],
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [10, 3],
+            [20, 23]
+          ]
+        }
+      }
+    },
+    {
+      "id": "highway_major_inner",
+      "type": "line",
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 11,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["in", "class", "primary", "secondary", "tertiary", "trunk"]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#fff",
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [10, 2],
+            [20, 20]
+          ]
+        }
+      }
+    },
+    {
+      "id": "highway_major_subtle",
+      "type": "line",
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "maxzoom": 11,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["in", "class", "primary", "secondary", "tertiary", "trunk"]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": { "line-color": "hsla(0, 0%, 85%, 0.69)", "line-width": 2 }
+    },
+    {
+      "id": "highway_motorway_casing",
+      "type": "line",
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 6,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!in", "brunnel", "bridge", "tunnel"],
+          ["==", "class", "motorway"]
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "miter",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgb(213, 213, 213)",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [5.8, 0],
+            [6, 3],
+            [20, 40]
+          ]
+        },
+        "line-dasharray": [2, 0],
+        "line-opacity": 1
+      }
+    },
+    {
+      "id": "highway_motorway_inner",
+      "type": "line",
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 6,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!in", "brunnel", "bridge", "tunnel"],
+          ["==", "class", "motorway"]
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": {
+          "base": 1,
+          "stops": [
+            [5.8, "hsla(0, 0%, 85%, 0.53)"],
+            [6, "#fff"]
+          ]
+        },
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [4, 2],
+            [6, 1.3],
+            [20, 30]
+          ]
+        }
+      }
+    },
+    {
+      "id": "highway_motorway_subtle",
+      "type": "line",
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "maxzoom": 6,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["==", "class", "motorway"]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsla(0, 0%, 85%, 0.53)",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [4, 2],
+            [6, 1.3]
+          ]
+        }
+      }
+    },
+    {
+      "id": "railway_transit",
+      "type": "line",
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 16,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["all", ["==", "class", "transit"], ["!in", "brunnel", "tunnel"]]
+      ],
+      "layout": { "visibility": "visible", "line-join": "round" },
+      "paint": { "line-color": "#dddddd", "line-width": 3 }
+    },
+    {
+      "id": "railway_transit_dashline",
+      "type": "line",
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 16,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["all", ["==", "class", "transit"], ["!in", "brunnel", "tunnel"]]
+      ],
+      "layout": { "visibility": "visible", "line-join": "round" },
+      "paint": {
+        "line-color": "#fafafa",
+        "line-width": 2,
+        "line-dasharray": [3, 3]
+      }
+    },
+    {
+      "id": "railway_service",
+      "type": "line",
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 16,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["all", ["==", "class", "rail"], ["has", "service"]]
+      ],
+      "layout": { "visibility": "visible", "line-join": "round" },
+      "paint": { "line-color": "#dddddd", "line-width": 3 }
+    },
+    {
+      "id": "railway_service_dashline",
+      "type": "line",
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 16,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["==", "class", "rail"],
+        ["has", "service"]
+      ],
+      "layout": { "visibility": "visible", "line-join": "round" },
+      "paint": {
+        "line-color": "#fafafa",
+        "line-width": 2,
+        "line-dasharray": [3, 3]
+      }
+    },
+    {
+      "id": "railway",
+      "type": "line",
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["all", ["!has", "service"], ["==", "class", "rail"]]
+      ],
+      "layout": { "visibility": "visible", "line-join": "round" },
+      "paint": {
+        "line-color": "#dddddd",
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [16, 3],
+            [20, 7]
+          ]
+        }
+      }
+    },
+    {
+      "id": "railway_dashline",
+      "type": "line",
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["all", ["!has", "service"], ["==", "class", "rail"]]
+      ],
+      "layout": { "visibility": "visible", "line-join": "round" },
+      "paint": {
+        "line-color": "#fafafa",
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [16, 2],
+            [20, 6]
+          ]
+        },
+        "line-dasharray": [3, 3]
+      }
+    },
+    {
+      "id": "highway_motorway_bridge_casing",
+      "type": "line",
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 6,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["all", ["==", "brunnel", "bridge"], ["==", "class", "motorway"]]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "miter",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgb(213, 213, 213)",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [5.8, 0],
+            [6, 5],
+            [20, 45]
+          ]
+        },
+        "line-dasharray": [2, 0],
+        "line-opacity": 1
+      }
+    },
+    {
+      "id": "highway_motorway_bridge_inner",
+      "type": "line",
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 6,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["all", ["==", "brunnel", "bridge"], ["==", "class", "motorway"]]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": {
+          "base": 1,
+          "stops": [
+            [5.8, "hsla(0, 0%, 85%, 0.53)"],
+            [6, "#fff"]
+          ]
+        },
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [4, 2],
+            [6, 1.3],
+            [20, 30]
+          ]
+        }
+      }
+    },
+    {
+      "id": "highway_name_other",
+      "type": "symbol",
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "source": "openmaptiles",
+      "source-layer": "transportation_name",
+      "filter": [
+        "all",
+        ["!=", "class", "motorway"],
+        ["==", "$type", "LineString"]
+      ],
+      "layout": {
+        "text-size": 10,
+        "text-max-angle": 30,
+        "text-transform": "uppercase",
+        "symbol-spacing": 350,
+        "text-font": ["Metropolis Regular", "Noto Sans Regular"],
+        "symbol-placement": "line",
+        "visibility": "visible",
+        "text-rotation-alignment": "map",
+        "text-pitch-alignment": "viewport",
+        "text-field": "{name:latin} {name:nonlatin}"
+      },
+      "paint": {
+        "text-color": "rgb(117, 129, 145)",
+        "text-halo-color": "#fff",
+        "text-translate": [0, 0],
+        "text-halo-width": 2,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "highway_name_motorway",
+      "type": "symbol",
+      "metadata": { "mapbox:group": "b6371a3f2f5a9932464fa3867530a2e5" },
+      "source": "openmaptiles",
+      "source-layer": "transportation_name",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["==", "class", "motorway"]
+      ],
+      "layout": {
+        "text-size": 10,
+        "symbol-spacing": 350,
+        "text-font": ["Metropolis Light", "Noto Sans Regular"],
+        "symbol-placement": "line",
+        "visibility": "visible",
+        "text-rotation-alignment": "viewport",
+        "text-pitch-alignment": "viewport",
+        "text-field": "{ref}"
+      },
+      "paint": {
+        "text-color": "rgb(117, 129, 145)",
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-translate": [0, 2],
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "boundary_state",
+      "type": "line",
+      "metadata": { "mapbox:group": "a14c9607bc7954ba1df7205bf660433f" },
+      "source": "openmaptiles",
+      "source-layer": "boundary",
+      "filter": ["==", "admin_level", 4],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(230, 204, 207, 0)",
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [3, 1],
+            [22, 15]
+          ]
+        },
+        "line-blur": 0.4,
+        "line-dasharray": [2, 2],
+        "line-opacity": 1
+      }
+    },
+    {
+      "id": "boundary_country",
+      "type": "line",
+      "metadata": { "mapbox:group": "a14c9607bc7954ba1df7205bf660433f" },
+      "source": "openmaptiles",
+      "source-layer": "boundary",
+      "filter": ["==", "admin_level", 2],
+      "layout": { "line-cap": "round", "line-join": "round" },
+      "paint": {
+        "line-color": "rgba(230, 204, 207, 0)",
+        "line-width": {
+          "base": 1.1,
+          "stops": [
+            [3, 1],
+            [22, 20]
+          ]
+        },
+        "line-blur": {
+          "base": 1,
+          "stops": [
+            [0, 0.4],
+            [22, 4]
+          ]
+        },
+        "line-opacity": 1
+      }
+    },
+    {
+      "id": "place_other",
+      "type": "symbol",
+      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "maxzoom": 14,
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "continent",
+          "hamlet",
+          "neighbourhood",
+          "isolated_dwelling"
+        ],
+        ["==", "$type", "Point"]
+      ],
+      "layout": {
+        "text-size": 10,
+        "text-transform": "uppercase",
+        "text-font": ["Metropolis Regular", "Noto Sans Regular"],
+        "text-justify": "center",
+        "visibility": "visible",
+        "text-anchor": "center",
+        "text-field": "{name:latin}\n{name:nonlatin}"
+      },
+      "paint": {
+        "text-color": "rgb(117, 129, 145)",
+        "text-halo-color": "rgb(242,243,240)",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "place_suburb",
+      "type": "symbol",
+      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "maxzoom": 15,
+      "filter": ["all", ["==", "$type", "Point"], ["==", "class", "suburb"]],
+      "layout": {
+        "text-size": 10,
+        "text-transform": "uppercase",
+        "text-font": ["Metropolis Regular", "Noto Sans Regular"],
+        "text-justify": "center",
+        "visibility": "visible",
+        "text-anchor": "center",
+        "text-field": "{name:latin}\n{name:nonlatin}"
+      },
+      "paint": {
+        "text-color": "rgb(117, 129, 145)",
+        "text-halo-color": "rgb(242,243,240)",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "place_village",
+      "type": "symbol",
+      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "maxzoom": 14,
+      "filter": ["all", ["==", "$type", "Point"], ["==", "class", "village"]],
+      "layout": {
+        "text-size": 10,
+        "text-transform": "uppercase",
+        "text-font": ["Metropolis Regular", "Noto Sans Regular"],
+        "text-justify": "center",
+        "visibility": "visible",
+        "text-anchor": "center",
+        "text-field": "{name:latin}\n{name:nonlatin}"
+      },
+      "paint": {
+        "text-color": "rgb(117, 129, 145)",
+        "text-halo-color": "rgb(242,243,240)",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "place_town",
+      "type": "symbol",
+      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "maxzoom": 15,
+      "filter": ["all", ["==", "$type", "Point"], ["==", "class", "town"]],
+      "layout": {
+        "text-size": 10,
+        "text-transform": "uppercase",
+        "text-font": ["Metropolis Regular", "Noto Sans Regular"],
+        "text-justify": "center",
+        "visibility": "visible",
+        "text-anchor": "center",
+        "text-field": "{name:latin}\n{name:nonlatin}"
+      },
+      "paint": {
+        "text-color": "rgb(117, 129, 145)",
+        "text-halo-color": "rgb(242,243,240)",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "place_city",
+      "type": "symbol",
+      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "maxzoom": 14,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["all", ["!=", "capital", 2], ["==", "class", "city"], [">", "rank", 3]]
+      ],
+      "layout": {
+        "text-size": 10,
+        "text-transform": "uppercase",
+        "text-font": ["Metropolis Regular", "Noto Sans Regular"],
+        "text-justify": "center",
+        "visibility": "visible",
+        "text-anchor": "center",
+        "text-field": "{name:latin}\n{name:nonlatin}"
+      },
+      "paint": {
+        "text-color": "rgb(117, 129, 145)",
+        "text-halo-color": "rgb(242,243,240)",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "place_capital",
+      "type": "symbol",
+      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "maxzoom": 12,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["all", ["==", "capital", 2], ["==", "class", "city"]]
+      ],
+      "layout": {
+        "text-size": 14,
+        "text-transform": "uppercase",
+        "text-font": ["Metropolis Regular", "Noto Sans Regular"],
+        "text-justify": "center",
+        "visibility": "visible",
+        "text-anchor": "center",
+        "text-field": "{name:latin}\n{name:nonlatin}"
+      },
+      "paint": {
+        "text-color": "rgb(117, 129, 145)",
+        "text-halo-color": "rgb(242,243,240)",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "place_city_large",
+      "type": "symbol",
+      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "maxzoom": 12,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        [
+          "all",
+          ["!=", "capital", 2],
+          ["<=", "rank", 3],
+          ["==", "class", "city"]
+        ]
+      ],
+      "layout": {
+        "text-size": 14,
+        "text-transform": "uppercase",
+        "text-font": ["Metropolis Regular", "Noto Sans Regular"],
+        "text-justify": "center",
+        "visibility": "visible",
+        "text-field": "{name:latin}\n{name:nonlatin}"
+      },
+      "paint": {
+        "text-color": "rgb(117, 129, 145)",
+        "text-halo-color": "rgb(242,243,240)",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "place_state",
+      "type": "symbol",
+      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "maxzoom": 12,
+      "filter": ["all", ["==", "$type", "Point"], ["==", "class", "state"]],
+      "layout": {
+        "visibility": "visible",
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": ["Metropolis Regular", "Noto Sans Regular"],
+        "text-transform": "uppercase",
+        "text-size": 10
+      },
+      "paint": {
+        "text-color": "rgb(113, 129, 144)",
+        "text-halo-color": "rgb(242,243,240)",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "place_country_other",
+      "type": "symbol",
+      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "maxzoom": 8,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["==", "class", "country"],
+        ["!has", "iso_a2"]
+      ],
+      "layout": {
+        "visibility": "visible",
+        "text-field": "{name:latin}",
+        "text-font": ["Metropolis Light Italic", "Noto Sans Italic"],
+        "text-transform": "uppercase",
+        "text-size": {
+          "base": 1,
+          "stops": [
+            [0, 9],
+            [6, 11]
+          ]
+        }
+      },
+      "paint": {
+        "text-halo-width": 1.4,
+        "text-halo-color": "rgba(236,236,234,0.7)",
+        "text-color": {
+          "base": 1,
+          "stops": [
+            [3, "rgb(157,169,177)"],
+            [4, "rgb(153, 153, 153)"]
+          ]
+        }
+      }
+    },
+    {
+      "id": "place_country_minor",
+      "type": "symbol",
+      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "maxzoom": 8,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["==", "class", "country"],
+        [">=", "rank", 2],
+        ["has", "iso_a2"]
+      ],
+      "layout": {
+        "visibility": "visible",
+        "text-field": "{name:latin}",
+        "text-font": ["Metropolis Regular", "Noto Sans Regular"],
+        "text-transform": "uppercase",
+        "text-size": {
+          "base": 1,
+          "stops": [
+            [0, 10],
+            [6, 12]
+          ]
+        }
+      },
+      "paint": {
+        "text-halo-width": 1.4,
+        "text-halo-color": "rgba(236,236,234,0.7)",
+        "text-color": {
+          "base": 1,
+          "stops": [
+            [3, "rgb(157,169,177)"],
+            [4, "rgb(153, 153, 153)"]
+          ]
+        }
+      }
+    },
+    {
+      "id": "place_country_major",
+      "type": "symbol",
+      "metadata": { "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f" },
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "maxzoom": 6,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["<=", "rank", 1],
+        ["==", "class", "country"],
+        ["has", "iso_a2"]
+      ],
+      "layout": {
+        "visibility": "visible",
+        "text-field": "{name:latin}",
+        "text-font": ["Metropolis Regular", "Noto Sans Regular"],
+        "text-transform": "uppercase",
+        "text-size": {
+          "base": 1.4,
+          "stops": [
+            [0, 10],
+            [3, 12],
+            [4, 14]
+          ]
+        },
+        "text-anchor": "center"
+      },
+      "paint": {
+        "text-halo-width": 1.4,
+        "text-halo-color": "rgba(236,236,234,0.7)",
+        "text-color": {
+          "base": 1,
+          "stops": [
+            [3, "rgb(157,169,177)"],
+            [4, "rgb(153, 153, 153)"]
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import { Box } from "@chakra-ui/react";
-import { Map } from "../components/Map";
+import { Map } from "@components/Map";
 
 const Index = () => (
   <Box h="800px" w="100%">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,8 @@
     "resolveJsonModule": true,
     "incremental": true,
     "paths": {
-      "@components/*": ["components/*"]
+      "@components/*": ["components/*"],
+      "@data/*": ["data/*"]
     }
   },
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,10 @@
     "target": "esnext",
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "incremental": true
+    "incremental": true,
+    "paths": {
+      "@components/*": ["components/*"]
+    }
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
### Summary
This PR points `<StaticMap>` at some static json added to the repo so that it will use the basemaps hosted at tiles.planninglabs.nyc. That JSON was copied from https://layers-api.planninglabs.nyc/static/v3.json and https://labs-layers-api.herokuapp.com/v1/base/style.json, with unnecessary `sources` removed to cut down the file size. Moving that JSON into this repo has the benefit of allowing us to use our tiles.planninglabs.nyc basemaps without having any references to layers-api. 

I'm open other approaches as well but hopefully this PR shows one approach and we can merge it in if we're happy with it.

#### Tasks/Bug Numbers
 - Fixes AB#5718
