### PR TITLE
6155 Foundational layout rework

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -9,12 +9,8 @@ export const Header = () => {
       spacing={4}
       paddingX={3}
       h="4.25rem"
-      backgroundColor="#fff"
-      zIndex="100"
-      position="fixed"
-      top="0"
-      left="0"
-      width="100%"
+      backgroundColor="white"
+      boxShadow="lg"
     >
       <Image
         src={logo}

--- a/src/components/IndicatorPanel/IndicatorPanel.tsx
+++ b/src/components/IndicatorPanel/IndicatorPanel.tsx
@@ -1,5 +1,4 @@
-import { Box, Collapse, useDisclosure, Text, Button } from "@chakra-ui/react";
-import { ChevronUpIcon, ChevronDownIcon } from "@chakra-ui/icons";
+import { Box, Heading, Text } from "@chakra-ui/react";
 import { NtaIndicatorRecord } from "../../types/Nta";
 
 interface IndicatorPanelProps {
@@ -7,56 +6,42 @@ interface IndicatorPanelProps {
 }
 
 export const IndicatorPanel = ({ indicatorRecord }: IndicatorPanelProps) => {
-  const { isOpen, onToggle } = useDisclosure();
-
   return (
-    <Box
-      background="#fff"
-      position={["relative", "absolute"]}
-      right={["auto", "0px"]}
-      top={["auto", "4.25rem"]}
-      bottom={["0px", "auto"]}
-      w={["100%", "350px"]}
-      marginTop={0}
-    >
-      <Button
-        w="100%"
-        onClick={onToggle}
-        justifyContent="space-between"
-        rightIcon={
-          isOpen ? (
-            <ChevronDownIcon w={10} h={10} />
-          ) : (
-            <ChevronUpIcon w={10} h={10} />
-          )
-        }
-      >
-        {indicatorRecord ? indicatorRecord.label : "Welcome"}
-      </Button>
-      <Collapse in={isOpen}>
-        {indicatorRecord ? (
-          <Box overflowY="auto" p={4} h="40vh">
-            <Text fontSize="lg">
-              Overall Displacement Risk: {indicatorRecord.displacementRisk}
-            </Text>
-            {Object.entries(indicatorRecord.indicators).map(
-              ([indicator, value]) => (
-                <Text py={2} key={`${indicatorRecord.id}-${indicator}`}>
+    <Box background="#fff" w={["100%"]} height="100%" p="15" rounded="lg">
+      <Heading as="h3" size="lg">
+        {indicatorRecord
+          ? indicatorRecord.label
+          : "Welcome to NYC's Equitable Development Data Tool"}
+      </Heading>
+
+      <hr />
+
+      {indicatorRecord ? (
+        <Box>
+          <Box p={2}>
+            Overall Displacement Risk: {indicatorRecord.displacementRisk}
+          </Box>
+          {Object.entries(indicatorRecord.indicators).map(
+            ([indicator, value]) => (
+              <Box key={`${indicatorRecord.id}-${indicator}`} p={2}>
+                <Text>
                   {indicator}: {value}
                 </Text>
-              )
-            )}
-          </Box>
-        ) : (
-          <Box overflowY="auto" p={4} h="40vh">
-            <Text>
-              The Equitable Development Reporting tool is a partnership between
-              NYC HPD and DCP. Please select an NTA from the map to view its
-              indicators
-            </Text>
-          </Box>
-        )}
-      </Collapse>
+              </Box>
+            )
+          )}
+        </Box>
+      ) : (
+        <Box p={2} h="40vh">
+          <Text>
+            You don&apos;t have anything selected yet.
+            <br />
+            The Equitable Development Reporting tool is a partnership between
+            NYC HPD and DCP. Please select an NTA from the map to view its
+            indicators
+          </Text>
+        </Box>
+      )}
     </Box>
   );
 };

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -1,4 +1,3 @@
-import { Box } from "@chakra-ui/react";
 import DeckGL from "@deck.gl/react";
 import { StaticMap } from "react-map-gl";
 import { setDefaultCredentials, API_VERSIONS } from "@deck.gl/carto";
@@ -12,10 +11,11 @@ setDefaultCredentials({
 });
 
 interface MapProps {
-  layers: CartoLayer<any, any>[];
+  layers: CartoLayer<any, any>[] | null;
+  mapParent: any;
 }
 
-export const Map = ({ layers }: MapProps) => {
+export const Map = ({ layers, mapParent }: MapProps) => {
   const INITIAL_VIEW_STATE = {
     longitude: -73.986607,
     latitude: 40.691869,
@@ -24,20 +24,19 @@ export const Map = ({ layers }: MapProps) => {
     bearing: 0,
   };
 
-  return (
-    <Box h="100%" w="100%" position="absolute" bottom="0" left="0">
-      <DeckGL
-        initialViewState={INITIAL_VIEW_STATE}
-        controller={true}
-        layers={layers}
-        width="100%"
-        height="100%"
-      >
-        <StaticMap
-          mapboxApiAccessToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN}
-          mapStyle={baseMap}
-        />
-      </DeckGL>
-    </Box>
+  const map = (
+    <DeckGL
+      initialViewState={INITIAL_VIEW_STATE}
+      controller={true}
+      layers={layers}
+      parent={mapParent.current}
+    >
+      <StaticMap
+        mapboxApiAccessToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN}
+        mapStyle={baseMap}
+      />
+    </DeckGL>
   );
+
+  return map;
 };

--- a/src/pages/map/[[...subroutes]].tsx
+++ b/src/pages/map/[[...subroutes]].tsx
@@ -1,17 +1,17 @@
 import { useRouter } from "next/router";
 
+import { useRef } from "react";
+
 import { Box, Flex } from "@chakra-ui/react";
 import { Map } from "@components/Map";
 import { Header } from "@components/Header";
-import { Legend } from "@components/Legend";
 import { IndicatorPanel } from "@components/IndicatorPanel";
-import { GeographySelect } from "@components/Map/GeographySelect/GeographySelect";
 
 import { useSelectedLayer } from "../../hooks/useSelectedLayer/useSelectedLayer";
 import { useIndicatorRecord } from "../../hooks/useIndicatorRecord/useIndicatorRecord";
 
 /*
-  /Map route
+  /Map route 
 
   Subroutes:
     /map/geography
@@ -36,30 +36,29 @@ const MapPage = () => {
 
   const indicatorRecord = useIndicatorRecord(geoid);
 
+  const mapContainer = useRef(null);
+
   return (
-    <Box height="100vh">
+    <Flex height="100vh" direction="column" bg="gray.100">
       <Header />
 
-      <Map layers={layers === null ? [] : layers} />
+      <Flex direction="row" flex="auto">
+        <Box flex="1" height="100%" p="10px">
+          <IndicatorPanel indicatorRecord={indicatorRecord} />
+        </Box>
 
-      <Flex direction="column" justify="end" height="100%">
-        <Legend
-          position={["relative", "absolute"]}
-          left={["auto", 8]}
-          bottom={["auto", 8]}
-          w={["100%", "215px"]}
-        />
-
-        <GeographySelect
-          geography={geography}
-          position={["relative", "absolute"]}
-          top={["auto", 20]}
-          left={["auto", 8]}
-        />
-
-        <IndicatorPanel indicatorRecord={indicatorRecord} />
+        <Box flex="2" height="100%" p="10px">
+          <Box
+            ref={mapContainer}
+            position="relative"
+            height="100%"
+            rounded="lg"
+          >
+            <Map layers={layers} mapParent={mapContainer} />
+          </Box>
+        </Box>
       </Flex>
-    </Box>
+    </Flex>
   );
 };
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/3311663/149224929-b1f7eca9-3353-4ba7-8b87-30d9a4839f71.png)

Fixes AB#6155 

This PR reworks the Flex layout  to  match that of the most  recent wireframes. The key ideas are:
  - Map is no longer absolutely  positioned to the  document root, but instead within a flexed box inside a flex layout.
  - Application  is organized into Flex containers. 
  - At the top level is a vertical flex, with two children -- one for holding the header,  one for the main content area
  - Main content area is a horizontal flex, with two  children -- one for the side panel, one for the map