### PR TITLE
5992 Change feature branch branch globs and update version commit message

### DIFF
--- a/.github/workflows/feature_branch.yml
+++ b/.github/workflows/feature_branch.yml
@@ -3,7 +3,8 @@ name: 🚧 Push to Feature Branch
 on:
   push:
     branches:
-      - feature/[0-9]+-*
+      - task/[0-9]+-*
+      - bug/[0-9]+-*
 
 jobs:
   cache-dependencies:

--- a/.github/workflows/release_and_deploy.yml
+++ b/.github/workflows/release_and_deploy.yml
@@ -178,7 +178,7 @@ jobs:
         run: |
           git config --local user.name "$SERVICE_ACCOUNT_NAME"
           git config --local user.email "$SERVICE_ACCOUNT_EMAIL"
-          npm version patch --commit-hooks false
+          npm version patch -m "version %s" --commit-hooks false
           git push https://${{ secrets.SERVICE_ACCOUNT_NAME }}:${{ secrets.SERVICE_ACCOUNT_PAT }}@github.com/${{ github.repository }}.git HEAD:main --follow-tags
       - name: Deploy to Production
         run: netlify deploy --prod --build


### PR DESCRIPTION
### Summary
This is a follow up to the original work for implementing these GH workflows. This PR changes the commit message used when running `npm version` so that it isn't just the version and it updates the branch name globs that trigger the feature_branch workflow to match our terminology in ADO - `task` and `bug` instead of `feature`


#### Tasks/Bug Numbers
 - Fixes AB#5992

