### PR TITLE
6309 Basic desktop-to-mobile pattern for Map page

### DIFF
--- a/src/pages/map/[[...subroutes]].tsx
+++ b/src/pages/map/[[...subroutes]].tsx
@@ -68,11 +68,42 @@ const MapPage = ({ initialRouteParams }: MapPageProps) => {
 
   return (
     <>
-      <Box flex="1" height="100%" p="10px">
+      <Box
+        display={{
+          base: "none",
+          lg: "flex",
+        }}
+        flex="1"
+        height="100%"
+        p="10px"
+      >
         <IndicatorPanel indicatorRecord={indicatorRecord} />
       </Box>
 
-      <Box flex="2" height="100%" p="10px">
+      <Box
+        display={{
+          base: "block",
+          lg: "none",
+        }}
+        width="100%"
+        position="fixed"
+        bottom="-800px"
+        left="0"
+        marginBottom="200px"
+        height="800px"
+        zIndex="999"
+      >
+        <IndicatorPanel indicatorRecord={indicatorRecord} />
+      </Box>
+
+      <Box
+        flex="2"
+        height="100%"
+        p={{
+          base: "none",
+          lg: "10px",
+        }}
+      >
         <Box ref={mapContainer} position="relative" height="100%" rounded="lg">
           <GeographySelect
             geography={geography}


### PR DESCRIPTION
Fixes AB#6309

This only implements switching between desktop and mobile positions for the Indicator Panel.
Desktop -- sits on the left as sidebar
Mobile -- sits on bottom as drawer.

Future tasks/PR implement drawer open and closing, etc. 

![image](https://user-images.githubusercontent.com/3311663/151040355-f679d257-2fc0-41cd-b68f-b605f44356c6.png)