### PR TITLE
6389 Style view toggle

### DIFF
--- a/cypress/integration/pages/Map/[[...subroutes]].spec.ts
+++ b/cypress/integration/pages/Map/[[...subroutes]].spec.ts
@@ -29,7 +29,7 @@ describe("Map catch-all page", () => {
       cy.contains("Census Area").should("have.attr", "data-active");
     });
 
-    it("should switch view when user uses ViewSelect toolbar", () => {
+    it("should switch view when user uses ViewToggle toolbar", () => {
       cy.url().should("include", "/map/datatool");
 
       cy.get('[data-cy="driBtn"]').click();
@@ -41,7 +41,7 @@ describe("Map catch-all page", () => {
       cy.url().should("include", "/map/datatool");
     });
 
-    it("ViewSelect should preserve previous view geo and geoid", () => {
+    it("ViewToggle should preserve previous view geo and geoid", () => {
       cy.visit("/map/datatool/census");
 
       cy.get('[data-cy="driBtn"]').click();

--- a/src/components/Map/ViewSelect.tsx
+++ b/src/components/Map/ViewSelect.tsx
@@ -1,10 +1,29 @@
-import { BoxProps, Button, ButtonGroup } from "@chakra-ui/react";
+import {
+  BoxProps,
+  Button,
+  ButtonGroup,
+  StylesProvider,
+  useMultiStyleConfig,
+} from "@chakra-ui/react";
 
 interface ViewSelectProps extends BoxProps {
   onDataToolClick: () => void;
   onDriClick: () => void;
   view: string | null;
 }
+
+// In this case we want implicit children
+const ThemedButtonGroup: React.FC = (props) => {
+  const { children, ...rest } = props;
+
+  const styles = useMultiStyleConfig("ButtonGroup", { variant: "toggle" });
+
+  return (
+    <ButtonGroup __css={styles.group} {...rest}>
+      <StylesProvider value={styles}>{children}</StylesProvider>
+    </ButtonGroup>
+  );
+};
 
 export const ViewSelect = ({
   onDataToolClick,
@@ -13,17 +32,23 @@ export const ViewSelect = ({
   ...boxProps
 }: ViewSelectProps) => {
   return (
-    <ButtonGroup isAttached {...boxProps}>
+    <ThemedButtonGroup {...boxProps}>
       <Button
         onClick={onDataToolClick}
         isActive={view === "datatool"}
+        variant="aqua"
         data-cy="dataToolBtn"
       >
         Data Tool
       </Button>
-      <Button onClick={onDriClick} isActive={view === "dri"} data-cy="driBtn">
+      <Button
+        onClick={onDriClick}
+        isActive={view === "dri"}
+        data-cy="driBtn"
+        variant="aqua"
+      >
         Displacement Risk Index
       </Button>
-    </ButtonGroup>
+    </ThemedButtonGroup>
   );
 };

--- a/src/components/Map/ViewSelect.tsx
+++ b/src/components/Map/ViewSelect.tsx
@@ -1,29 +1,11 @@
-import {
-  BoxProps,
-  Button,
-  ButtonGroup,
-  StylesProvider,
-  useMultiStyleConfig,
-} from "@chakra-ui/react";
+import { BoxProps, Button } from "@chakra-ui/react";
+import { ToggleButtonGroup } from "@components/ToggleButtonGroup";
 
 interface ViewSelectProps extends BoxProps {
   onDataToolClick: () => void;
   onDriClick: () => void;
   view: string | null;
 }
-
-// In this case we want implicit children
-const ThemedButtonGroup: React.FC = (props) => {
-  const { children, ...rest } = props;
-
-  const styles = useMultiStyleConfig("ButtonGroup", { variant: "toggle" });
-
-  return (
-    <ButtonGroup __css={styles.group} {...rest}>
-      <StylesProvider value={styles}>{children}</StylesProvider>
-    </ButtonGroup>
-  );
-};
 
 export const ViewSelect = ({
   onDataToolClick,
@@ -32,7 +14,7 @@ export const ViewSelect = ({
   ...boxProps
 }: ViewSelectProps) => {
   return (
-    <ThemedButtonGroup {...boxProps}>
+    <ToggleButtonGroup {...boxProps}>
       <Button
         onClick={onDataToolClick}
         isActive={view === "datatool"}
@@ -49,6 +31,6 @@ export const ViewSelect = ({
       >
         Displacement Risk Index
       </Button>
-    </ThemedButtonGroup>
+    </ToggleButtonGroup>
   );
 };

--- a/src/components/Map/ViewToggle.tsx
+++ b/src/components/Map/ViewToggle.tsx
@@ -1,18 +1,18 @@
 import { BoxProps, Button } from "@chakra-ui/react";
 import { ToggleButtonGroup } from "@components/ToggleButtonGroup";
 
-interface ViewSelectProps extends BoxProps {
+interface ViewToggleProps extends BoxProps {
   onDataToolClick: () => void;
   onDriClick: () => void;
   view: string | null;
 }
 
-export const ViewSelect = ({
+export const ViewToggle = ({
   onDataToolClick,
   onDriClick,
   view,
   ...boxProps
-}: ViewSelectProps) => {
+}: ViewToggleProps) => {
   return (
     <ToggleButtonGroup {...boxProps}>
       <Button

--- a/src/components/Map/ViewToggle.tsx
+++ b/src/components/Map/ViewToggle.tsx
@@ -18,7 +18,7 @@ export const ViewToggle = ({
       <Button
         onClick={onDataToolClick}
         isActive={view === "datatool"}
-        variant="aqua"
+        variant="toggle"
         data-cy="dataToolBtn"
       >
         Data Tool
@@ -27,7 +27,7 @@ export const ViewToggle = ({
         onClick={onDriClick}
         isActive={view === "dri"}
         data-cy="driBtn"
-        variant="aqua"
+        variant="toggle"
       >
         Displacement Risk Index
       </Button>

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -1,4 +1,4 @@
 export * from "./Map";
 export * from "./DataTool";
-export * from "./ViewSelect";
+export * from "./ViewToggle";
 export * from "./MobileDrawer";

--- a/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -1,0 +1,18 @@
+import {
+  ButtonGroup,
+  StylesProvider,
+  useMultiStyleConfig,
+} from "@chakra-ui/react";
+
+// In this case we want implicit children
+export const ToggleButtonGroup: React.FC = (props) => {
+  const { children, ...rest } = props;
+
+  const styles = useMultiStyleConfig("ButtonGroup", { variant: "toggle" });
+
+  return (
+    <ButtonGroup __css={styles.group} {...rest}>
+      <StylesProvider value={styles}>{children}</StylesProvider>
+    </ButtonGroup>
+  );
+};

--- a/src/components/ToggleButtonGroup/index.ts
+++ b/src/components/ToggleButtonGroup/index.ts
@@ -1,0 +1,1 @@
+export * from "./ToggleButtonGroup";

--- a/src/pages/map/[[...subroutes]].tsx
+++ b/src/pages/map/[[...subroutes]].tsx
@@ -5,7 +5,7 @@ import { Box } from "@chakra-ui/react";
 import { useSelectedLayer } from "@hooks/useSelectedLayer";
 import { useIndicatorRecord } from "@hooks/useIndicatorRecord";
 import { IndicatorPanel } from "@components/IndicatorPanel";
-import { Map, MobileDrawer, ViewSelect } from "@components/Map";
+import { Map, MobileDrawer, ViewToggle } from "@components/Map";
 import { GeographySelect as DataToolGeographySelect } from "@components/Map/DataTool";
 
 export interface MapPageProps {
@@ -138,7 +138,7 @@ const MapPage = ({ initialRouteParams }: MapPageProps) => {
 
       <Box flex="2" height="100%">
         <Box ref={mapContainer} position="relative" height="100%" rounded="lg">
-          <ViewSelect
+          <ViewToggle
             onDataToolClick={onDataToolClick}
             onDriClick={onDriClick}
             view={view}

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -16,6 +16,38 @@ const theme = extendTheme({
   },
   fonts,
   breakpoints,
+  components: {
+    ButtonGroup: {
+      parts: ["group", "button"],
+      variants: {
+        toggle: {
+          group: {
+            backgroundColor: "white",
+            borderRadius: 50,
+          },
+        },
+      },
+    },
+    Button: {
+      variants: {
+        aqua: {
+          backgroundColor: "white",
+          color: "gray.600",
+          borderRadius: 50,
+
+          _hover: {
+            color: "teal",
+          },
+          _active: {
+            backgroundColor: "teal.50",
+            border: "1px solid teal",
+            color: "teal",
+            borderRadius: 50,
+          },
+        },
+      },
+    },
+  },
 });
 
 export default theme;

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -30,7 +30,7 @@ const theme = extendTheme({
     },
     Button: {
       variants: {
-        aqua: {
+        toggle: {
           backgroundColor: "white",
           color: "gray.600",
           borderRadius: 50,


### PR DESCRIPTION
Finalizes [AB#6389](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/6389)

Styles the toggle according to specs through the Chakra UI default theme.

Safari:
![image](https://user-images.githubusercontent.com/3311663/152188247-54f9121d-1971-4d06-a6d4-adb71cdbaa9c.png)
![image](https://user-images.githubusercontent.com/3311663/152188260-27494390-3f04-49c9-8667-c21726f50b2d.png)


Chrome (browser introduces blue highlights around links). TODO: figure out how to apply webkit styles in chakra ui to prevent the highlighting
![image](https://user-images.githubusercontent.com/3311663/152188001-1b3c8eee-9643-4bb6-a3a6-f9b57e3459cb.png)
![image](https://user-images.githubusercontent.com/3311663/152188025-4731bdb5-7220-4a7a-a28c-8de13fc5ca00.png)
