### PR TITLE
6588 Adjust map page padding and shadows to match specs

### DIFF
--- a/src/pages/map/[[...subroutes]].tsx
+++ b/src/pages/map/[[...subroutes]].tsx
@@ -126,6 +126,8 @@ const MapPage = ({ initialRouteParams }: MapPageProps) => {
         flex="1"
         height="100%"
         p="10px"
+        boxShadow="lg"
+        zIndex="999"
       >
         <IndicatorPanel indicatorRecord={indicatorRecord} />
       </Box>
@@ -146,14 +148,7 @@ const MapPage = ({ initialRouteParams }: MapPageProps) => {
         <IndicatorPanel indicatorRecord={indicatorRecord} />
       </Box>
 
-      <Box
-        flex="2"
-        height="100%"
-        p={{
-          base: "none",
-          lg: "10px",
-        }}
-      >
+      <Box flex="2" height="100%">
         <Box ref={mapContainer} position="relative" height="100%" rounded="lg">
           <ViewSelect
             onDataToolClick={onDataToolClick}


### PR DESCRIPTION
Fixes [AB#6588](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/6588) 

### Summary
Quick adjustment to map page to match wireframes. 
 - Removes padding between map and sidebar/header
 -  Adds box shadow to desktop sidebar
![image](https://user-images.githubusercontent.com/3311663/152380732-97179b87-70bc-45b9-b80f-dd9616f050f5.png)
