### PR TITLE
Task/6637 remove build artifact

### DIFF
--- a/.github/workflows/feature_branch.yml
+++ b/.github/workflows/feature_branch.yml
@@ -78,11 +78,46 @@ jobs:
       - name: Run tests
         run: npm run test
 
-  build:
-    name: 📦 Build Next.js
-    runs-on: ubuntu-latest
+  # build:
+  #   name: 📦 Build Next.js
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - lint
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Setup node env
+  #       uses: actions/setup-node@v2.1.2
+  #       with:
+  #         node-version: 16
+  #     - name: Restore dependencies
+  #       uses: actions/cache@v2
+  #       id: npm-cache
+  #       with:
+  #         path: |
+  #           ~/.cache/Cypress
+  #           node_modules
+  #         key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-npm
+  #     - name: Build Next.js
+  #       run: npm run build
+  #       env:
+  #         NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+  #         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+  #         NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
+  #         NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
+  #         NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
+  #     - name: Upload build artifact
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: build
+  #         path: .next
+
+  e2e:
+    name: 🧪 End To End Tests
     needs:
       - lint
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Setup node env
@@ -99,7 +134,7 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-npm
-      - name: Build Next.js
+      - name: Build Project
         run: npm run build
         env:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
@@ -107,38 +142,6 @@ jobs:
           NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
           NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
           NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: build
-          path: .next
-
-  e2e:
-    name: 🧪 End To End Tests
-    needs:
-      - build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup node env
-        uses: actions/setup-node@v2.1.2
-        with:
-          node-version: 16
-      - name: Restore dependencies
-        uses: actions/cache@v2
-        id: npm-cache
-        with:
-          path: |
-            ~/.cache/Cypress
-            node_modules
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm
-      - name: Download build artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: build
-          path: .next
       - name: Run e2e test
         run: npm run e2e:test
 

--- a/.github/workflows/feature_branch.yml
+++ b/.github/workflows/feature_branch.yml
@@ -78,41 +78,6 @@ jobs:
       - name: Run tests
         run: npm run test
 
-  # build:
-  #   name: 📦 Build Next.js
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - lint
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Setup node env
-  #       uses: actions/setup-node@v2.1.2
-  #       with:
-  #         node-version: 16
-  #     - name: Restore dependencies
-  #       uses: actions/cache@v2
-  #       id: npm-cache
-  #       with:
-  #         path: |
-  #           ~/.cache/Cypress
-  #           node_modules
-  #         key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-npm
-  #     - name: Build Next.js
-  #       run: npm run build
-  #       env:
-  #         NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-  #         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-  #         NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
-  #         NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
-  #         NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
-  #     - name: Upload build artifact
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: build
-  #         path: .next
-
   e2e:
     name: 🧪 End To End Tests
     needs:

--- a/.github/workflows/pr_merged.yml
+++ b/.github/workflows/pr_merged.yml
@@ -78,41 +78,6 @@ jobs:
       - name: Run tests
         run: npm run test
 
-  build:
-    name: 📦 Build Next.js
-    runs-on: ubuntu-latest
-    needs:
-      - lint
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup node env
-        uses: actions/setup-node@v2.1.2
-        with:
-          node-version: 16
-      - name: Restore dependencies
-        uses: actions/cache@v2
-        id: npm-cache
-        with:
-          path: |
-            ~/.cache/Cypress
-            node_modules
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm
-      - name: Build Next.js
-        run: npm run build
-        env:
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
-          NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
-          NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: build
-          path: .next
-
   e2e:
     name: 🧪 End To End Tests
     needs:
@@ -134,11 +99,14 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-npm
-      - name: Download build artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: build
-          path: .next
+      - name: Build Project
+        run: npm run build
+        env:
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
+          NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
+          NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
       - name: Run e2e test
         run: npm run e2e:test
 

--- a/.github/workflows/release_and_deploy.yml
+++ b/.github/workflows/release_and_deploy.yml
@@ -79,11 +79,11 @@ jobs:
       - name: Run tests
         run: npm run test
 
-  build:
-    name: 📦 Build Next.js
-    runs-on: ubuntu-latest
+  e2e:
+    name: 🧪 End To End Tests
     needs:
-      - lint
+      - build
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
@@ -110,40 +110,6 @@ jobs:
           NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
           NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
           NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: build
-          path: .next
-
-  e2e:
-    name: 🧪 End To End Tests
-    needs:
-      - build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: 'main'
-      - name: Setup node env
-        uses: actions/setup-node@v2.1.2
-        with:
-          node-version: 16
-      - name: Restore dependencies
-        uses: actions/cache@v2
-        id: npm-cache
-        with:
-          path: |
-            ~/.cache/Cypress
-            node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-      - name: Download a single artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: build
-          path: .next
       - name: Run e2e test
         run: npm run e2e:test
 


### PR DESCRIPTION
### Summary
This PR makes a change to our GH actions. We had separate Jobs for building the project and performing e2e tests. Because of how we do a build for deployment with the Netlify CLI, the build done in the "Build" job was only used for e2e tests so saving the Build as an Artifact is unnecessary. This change moves the build to just be a step within e2e tests so it won't be saved as an artifact at all. Note that if we ever do have to change it back to being an artifact, we should set a short retention period so we aren't clogging up our GH artifact storage.

#### Tasks/Bug Numbers
 - Fixes [AB#6637](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/6637)
