### PR TITLE
Fix bug in staging and prod action workflows

### DIFF
--- a/.github/workflows/pr_merged.yml
+++ b/.github/workflows/pr_merged.yml
@@ -81,7 +81,7 @@ jobs:
   e2e:
     name: 🧪 End To End Tests
     needs:
-      - build
+      - lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release_and_deploy.yml
+++ b/.github/workflows/release_and_deploy.yml
@@ -82,7 +82,7 @@ jobs:
   e2e:
     name: 🧪 End To End Tests
     needs:
-      - build
+      - lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
### Summary
This PR fixes a bug in the GH workflows related to a change to remove the creation of build artifacts. This bug made it into `main` because those actions don't run until a push to `main` happens.

#### Tasks/Bug Numbers
 - Fixes AB#6637

