### PR TITLE
6745 Show NTA geography layer for DRI View

### DIFF
--- a/cypress/integration/pages/Map/[[...subroutes]].spec.ts
+++ b/cypress/integration/pages/Map/[[...subroutes]].spec.ts
@@ -34,7 +34,7 @@ describe("Map catch-all page", () => {
 
       cy.get('[data-cy="driBtn-desktop"]').click();
 
-      cy.url().should("include", "/map/dri/puma");
+      cy.url().should("include", "/map/dri/nta");
 
       cy.get('[data-cy="dataToolBtn-desktop"]').click();
 
@@ -46,7 +46,7 @@ describe("Map catch-all page", () => {
 
       cy.get('[data-cy="driBtn-desktop"]').click();
 
-      cy.url().should("include", "/map/dri/puma");
+      cy.url().should("include", "/map/dri/nta");
 
       cy.get('[data-cy="dataToolBtn-desktop"]').click();
 
@@ -56,7 +56,7 @@ describe("Map catch-all page", () => {
 
       cy.get('[data-cy="driBtn-desktop"]').click();
 
-      cy.url().should("include", "/map/dri/puma");
+      cy.url().should("include", "/map/dri/nta");
 
       cy.get('[data-cy="dataToolBtn-desktop"]').click();
 
@@ -87,7 +87,7 @@ describe("Map catch-all page", () => {
 
       cy.get('[data-cy="driBtn-mobile"]').click();
 
-      cy.url().should("include", "/map/dri/puma");
+      cy.url().should("include", "/map/dri/nta");
 
       cy.get('[data-cy="dataToolBtn-mobile"]').click();
 

--- a/src/hooks/useSelectedLayer/useSelectedLayer.ts
+++ b/src/hooks/useSelectedLayer/useSelectedLayer.ts
@@ -80,6 +80,36 @@ export const useSelectedLayer = (
         return null;
         break;
     }
+  } else if (view === "dri") {
+    switch (geography) {
+      case "nta":
+        return [
+          new CartoLayer({
+            type: MAP_TYPES.QUERY,
+            id: "nta",
+            data: `SELECT * FROM dcp_nta_2010`,
+            uniqueIdProperty: "id",
+            getLineColor: [100, 100, 100, 255],
+            getFillColor: [0, 0, 0, 0],
+            lineWidthMinPixels: 3,
+            stroked: true,
+            pickable: true,
+            onClick: (info: any) => {
+              const id: any = info?.object?.properties?.id
+                ? info.object.properties.id
+                : null;
+              if (typeof id === "string") {
+                // ugh https://github.com/vercel/next.js/issues/9473
+                router.push(`map/datatool/census/${id}`);
+              }
+            },
+          }),
+        ];
+        break;
+      default:
+        return null;
+        break;
+    }
   }
 
   return [];

--- a/src/pages/map/[[...subroutes]].tsx
+++ b/src/pages/map/[[...subroutes]].tsx
@@ -90,7 +90,7 @@ const MapPage = ({ initialRouteParams }: MapPageProps) => {
     setLastDataToolGeography(geography);
     setLastDataToolGeoid(geoid);
 
-    let driPath = "/map/dri/puma";
+    let driPath = "/map/dri/nta";
 
     if (lastDriGeoid) {
       driPath += `/${lastDriGeoid}`;


### PR DESCRIPTION
Added the NTA geography layer, made it automatically display when a user toggles to DRI view.

<!---
   The below template is a general guide, but not a strict prescription!
-->

 - Finishes [AB#6745](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/6745)
<!---
Provide a link to a ticket, if applicable
-->
Pulling from the "dcp_nta_2010" carto dataset.
