### PR TITLE
Task/6653 Position navigation control according to spec

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -8,6 +8,7 @@ import { setDefaultCredentials, API_VERSIONS } from "@deck.gl/carto";
 import baseMap from "@data/basemap.json";
 
 import { Box } from "@chakra-ui/react";
+import { useView } from "@hooks/useView";
 
 setDefaultCredentials({
   apiVersion: API_VERSIONS.V2,
@@ -18,6 +19,8 @@ setDefaultCredentials({
 type MapProps = Pick<DeckGLProps, "layers" | "parent">;
 
 export const Map = ({ layers, parent }: MapProps) => {
+  const view = useView();
+
   const INITIAL_VIEW_STATE = {
     longitude: -73.986607,
     latitude: 40.691869,
@@ -39,13 +42,12 @@ export const Map = ({ layers, parent }: MapProps) => {
       ContextProvider={MapContext.Provider}
     >
       <Box
-        display={{
-          base: "none",
-          lg: "block",
-        }}
         position="absolute"
-        bottom={150}
-        left={10}
+        top={{
+          base: view === "datatool" ? "5rem" : "1.3rem",
+          lg: "5rem",
+        }}
+        left="2.1875rem"
       >
         <NavigationControl />
       </Box>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -9,7 +9,7 @@ import { AppProps } from "next/app";
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <ChakraProvider resetCSS theme={theme}>
-      <Flex height="100vh" direction="column">
+      <Flex height="100vh" direction="column" overflow="hidden">
         <Header />
 
         <Flex direction="row" flex="auto">

--- a/src/pages/map/[[...subroutes]].tsx
+++ b/src/pages/map/[[...subroutes]].tsx
@@ -153,7 +153,14 @@ const MapPage = ({ initialRouteParams }: MapPageProps) => {
               geography={geography}
               position="absolute"
               top={5}
-              right={8}
+              right={{
+                lg: 8,
+                base: "auto",
+              }}
+              left={{
+                lg: "auto",
+                base: "2.1875rem",
+              }}
               zIndex={100}
               boxShadow="lg"
             />


### PR DESCRIPTION
Fixes AB#6653

- Positiones the nav control according to figma spec. 
- Desktop: sits top right, under the View Toggle
- Mobile: sits top right, at corner edge if in DRI view. Otherwise, just under the Geography Toggle in Data Tool view. 