### PR TITLE
Ad hoc houskeeping: Fix Geo Options labels, default geo 

### DIFF
--- a/cypress/integration/pages/Map/[[...subroutes]].spec.ts
+++ b/cypress/integration/pages/Map/[[...subroutes]].spec.ts
@@ -16,17 +16,17 @@ describe("Map catch-all page", () => {
     it("should switch geography when user uses Geography Select toolbar on Desktop size", () => {
       cy.url().should("include", "/map/datatool");
 
-      cy.contains("Census").click();
+      cy.contains("Community District*").click();
 
-      cy.url().should("include", "/map/datatool/census");
+      cy.url().should("include", "/map/datatool/district");
 
       cy.contains("Borough").click();
 
       cy.url().should("include", "/map/datatool/borough");
 
-      cy.visit("/map/datatool/census");
+      cy.visit("/map/datatool/district");
 
-      cy.contains("Census Area").should("have.attr", "data-active");
+      cy.contains("Community District*").should("have.attr", "data-active");
     });
 
     it("should switch view when user uses ViewToggle toolbar", () => {
@@ -42,7 +42,7 @@ describe("Map catch-all page", () => {
     });
 
     it("ViewToggle should preserve previous view geo and geoid", () => {
-      cy.visit("/map/datatool/census");
+      cy.visit("/map/datatool/district");
 
       cy.get('[data-cy="driBtn-desktop"]').click();
 
@@ -50,7 +50,7 @@ describe("Map catch-all page", () => {
 
       cy.get('[data-cy="dataToolBtn-desktop"]').click();
 
-      cy.url().should("include", "/map/datatool/census");
+      cy.url().should("include", "/map/datatool/district");
 
       cy.visit("/map/datatool/borough/BK0202");
 

--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,7 @@ module.exports = {
     return [
       {
         source: "/",
-        destination: "/map/datatool/census",
+        destination: "/map/datatool/district",
         permanent: true,
       },
     ];

--- a/src/components/Map/DataTool/GeographySelect/GeographySelect.tsx
+++ b/src/components/Map/DataTool/GeographySelect/GeographySelect.tsx
@@ -15,11 +15,11 @@ export const GeographySelect = ({
   return (
     <ToggleButtonGroup isAttached={true} {...boxProps}>
       <Button
-        onClick={() => router.push({ pathname: `/map/datatool/census` })}
-        isActive={geography === "census"}
+        onClick={() => router.push({ pathname: `/map/datatool/district` })}
+        isActive={geography === "district"}
         variant="leftCap"
       >
-        Census Area
+        Community District*
       </Button>
       <Button
         onClick={() => router.push({ pathname: `/map/datatool/borough` })}

--- a/src/hooks/useSelectedLayer/useSelectedLayer.ts
+++ b/src/hooks/useSelectedLayer/useSelectedLayer.ts
@@ -17,7 +17,7 @@ export const useSelectedLayer = (
 
   if (view === "datatool") {
     switch (geography) {
-      case "census":
+      case "district":
         return [
           new CartoLayer({
             type: MAP_TYPES.QUERY,
@@ -35,7 +35,7 @@ export const useSelectedLayer = (
                 : null;
               if (typeof id === "string") {
                 // ugh https://github.com/vercel/next.js/issues/9473
-                router.push(`map/datatool/census/${id}`);
+                router.push(`map/datatool/district/${id}`);
               }
             },
           }),
@@ -100,7 +100,7 @@ export const useSelectedLayer = (
                 : null;
               if (typeof id === "string") {
                 // ugh https://github.com/vercel/next.js/issues/9473
-                router.push(`map/datatool/census/${id}`);
+                router.push(`map/dri/nta/${id}`);
               }
             },
           }),

--- a/src/pages/map/[[...subroutes]].tsx
+++ b/src/pages/map/[[...subroutes]].tsx
@@ -111,6 +111,8 @@ const MapPage = ({ initialRouteParams }: MapPageProps) => {
       if (lastDataToolGeoid) {
         dataToolPath += `/${lastDataToolGeoid}`;
       }
+    } else {
+      dataToolPath += "/district";
     }
 
     router.push({ pathname: dataToolPath });

--- a/test/components/GeographySelect/GeographySelect.test.js
+++ b/test/components/GeographySelect/GeographySelect.test.js
@@ -28,15 +28,17 @@ it("GeographySelect has at least three options", () => {
   expect(screen.queryAllByRole("button")).toHaveLength(3);
 });
 
-it("GeographySelect correctly indicates active Census geography", () => {
+it("GeographySelect correctly indicates active Community District geography", () => {
   act(() => {
     const {} = render( // eslint-disable-line
-      <GeographySelect geography="census" />,
+      <GeographySelect geography="district" />,
       container
     );
   });
 
-  expect(screen.getByText("Census Area")).toHaveAttribute("data-active");
+  expect(screen.getByText("Community District*")).toHaveAttribute(
+    "data-active"
+  );
   expect(screen.getByText("Borough")).not.toHaveAttribute("data-active");
   expect(screen.getByText("Citywide")).not.toHaveAttribute("data-active");
 });
@@ -49,7 +51,9 @@ it("GeographySelect correctly indicates active Borough geography", () => {
     );
   });
 
-  expect(screen.getByText("Census Area")).not.toHaveAttribute("data-active");
+  expect(screen.getByText("Community District*")).not.toHaveAttribute(
+    "data-active"
+  );
   expect(screen.getByText("Borough")).toHaveAttribute("data-active");
   expect(screen.getByText("Citywide")).not.toHaveAttribute("data-active");
 });
@@ -62,7 +66,9 @@ it("GeographySelect correctly indicates active Citywide geography", () => {
     );
   });
 
-  expect(screen.getByText("Census Area")).not.toHaveAttribute("data-active");
+  expect(screen.getByText("Community District*")).not.toHaveAttribute(
+    "data-active"
+  );
   expect(screen.getByText("Borough")).not.toHaveAttribute("data-active");
   expect(screen.getByText("Citywide")).toHaveAttribute("data-active");
 });


### PR DESCRIPTION
Fixes the first geography option label (Census -> Community District) in the GeographySelect toggle. 
<img width="458" alt="image" src="https://user-images.githubusercontent.com/3311663/154119465-9477c214-6972-4666-9144-5baf9c559779.png">

Also makes sure that if a user landed directly on the DRI view, then transitioned to the Data Tool, the default geography selected is Community District.
