### PR TITLE
Remove `overflow: hidden` from  app container. 

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -9,7 +9,7 @@ import { AppProps } from "next/app";
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <ChakraProvider resetCSS theme={theme}>
-      <Flex height="100vh" direction="column" overflow="hidden">
+      <Flex height="100vh" direction="column">
         <Header />
 
         <Flex direction="row" flex="auto">


### PR DESCRIPTION
@TylerMatteo  I should have heeded your caution. Sorry. The overflow hidden borked the About and Methods pages (unscrollable). Fail. 🤦🏾 