### PR TITLE
6855 Connect GeographySelect btns to correct Carto layers

### DIFF
--- a/src/hooks/useSelectedLayer/useSelectedLayer.ts
+++ b/src/hooks/useSelectedLayer/useSelectedLayer.ts
@@ -1,10 +1,5 @@
 import { useRouter } from "next/router";
 import { CartoLayer, MAP_TYPES } from "@deck.gl/carto";
-import { scaleSequential } from "d3-scale";
-import { rgb } from "d3-color";
-import { interpolateRgb } from "d3-interpolate";
-
-import ntas from "@data/ntas.json";
 
 export const useSelectedLayer = (
   view: string | null,
@@ -12,17 +7,14 @@ export const useSelectedLayer = (
 ): CartoLayer<any, any>[] | null => {
   const router = useRouter();
 
-  const scale = scaleSequential().domain([0, 100]);
-  const interpolate = interpolateRgb("#f4f4b4", "#d44932");
-
   if (view === "datatool") {
     switch (geography) {
       case "district":
         return [
           new CartoLayer({
             type: MAP_TYPES.QUERY,
-            id: "censusarea",
-            data: `SELECT * FROM pff_2020_census_tracts_21c`,
+            id: "puma",
+            data: `SELECT * FROM dcp_puma`,
             uniqueIdProperty: "id",
             getLineColor: [100, 100, 100, 255],
             getFillColor: [0, 0, 0, 0],
@@ -30,12 +22,12 @@ export const useSelectedLayer = (
             stroked: true,
             pickable: true,
             onClick: (info: any) => {
-              const id: any = info?.object?.properties?.id
-                ? info.object.properties.id
+              const id: any = info?.object?.properties?.puma
+                ? info.object.properties.puma
                 : null;
               if (typeof id === "string") {
                 // ugh https://github.com/vercel/next.js/issues/9473
-                router.push(`map/datatool/district/${id}`);
+                router.push(`/map/datatool/district/${id}`);
               }
             },
           }),
@@ -45,29 +37,18 @@ export const useSelectedLayer = (
         return [
           new CartoLayer({
             type: MAP_TYPES.QUERY,
-            id: "nta",
-            data: `SELECT *, nta2020 as id, ntaname as label FROM dcp_nta_2020 WHERE ntatype = '0'`,
+            id: "borough",
+            data: `SELECT * FROM dcp_borough_boundary`,
             uniqueIdProperty: "id",
             getLineColor: [100, 100, 100, 255],
-            getFillColor: (feature: any) => {
-              if (feature?.properties?.id) {
-                const id: keyof typeof ntas = feature?.properties?.id;
-                if (typeof ntas[id] !== "undefined") {
-                  const color = rgb(
-                    interpolate(scale(ntas[id].displacementRisk))
-                  );
-                  return [color.r, color.g, color.b, 100];
-                }
-                return [0, 0, 0, 0];
-              }
-              return [0, 0, 0, 0];
-            },
+            getFillColor: [0, 0, 0, 0],
             lineWidthMinPixels: 3,
             stroked: true,
             pickable: true,
             onClick: (info: any) => {
-              const id: any = info?.object?.properties?.id
-                ? info.object.properties.id
+              // TODO: Translate to borocode if needed for data lookup
+              const id: any = info?.object?.properties?.boroname
+                ? info.object.properties.boroname
                 : null;
               if (typeof id === "string") {
                 router.push({ pathname: `/map/datatool/borough/${id}` });
@@ -75,10 +56,21 @@ export const useSelectedLayer = (
             },
           }),
         ];
-        break;
+      case "citywide":
+        return [
+          new CartoLayer({
+            type: MAP_TYPES.QUERY,
+            id: "city",
+            data: `SELECT * FROM pff_2020_city_21c`,
+            uniqueIdProperty: "id",
+            getLineColor: [100, 100, 100, 255],
+            getFillColor: [0, 0, 0, 0],
+            lineWidthMinPixels: 3,
+            stroked: true,
+          }),
+        ];
       default:
         return null;
-        break;
     }
   } else if (view === "dri") {
     switch (geography) {


### PR DESCRIPTION
 - Fixes [AB#6855](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/6855)

Stepping stone PR for work on the Data Tool sidebar. 

We are going to use the `dcp_puma` layer  for Community District because it is so called "Data Pipeline"-ed (maintained by GIS). Although it doesn't have neighborhood information, Erica has given us a lookup table for the PUMA description and CD associations per PUMA.