### PR TITLE
6877 6883  Selected Geography Information

### DIFF
--- a/src/components/DrawerContent/DrawerContent.tsx
+++ b/src/components/DrawerContent/DrawerContent.tsx
@@ -1,17 +1,16 @@
 import React from "react";
+import { GeographyInfo } from "@components/GeographyInfo";
 import WelcomeContent from "@components/WelcomeContent";
 import WelcomeFooter from "@components/WelcomeFooter";
 import { useMapSubrouteInfo } from "@hooks/useMapSubrouteInfo";
 
 export const DrawerContent = () => {
-  const { geoid } = useMapSubrouteInfo();
+  const { geography, geoid } = useMapSubrouteInfo();
 
-  if (geoid !== null) {
+  if (geoid !== null || geography === "citywide") {
     return (
       <>
-        Either Data Tool Categories or DRI Indicators go here
-        <br />
-        (you can use useView() to determine which)
+        <GeographyInfo />
       </>
     );
   }

--- a/src/components/GeographyInfo/GeographyInfo.tsx
+++ b/src/components/GeographyInfo/GeographyInfo.tsx
@@ -2,6 +2,7 @@ import { CloseIcon } from "@chakra-ui/icons";
 import { Heading, Box, Button } from "@chakra-ui/react";
 import { useMapSubrouteInfo } from "@hooks/useMapSubrouteInfo";
 import { usePumaInfo } from "@hooks/usePumaInfo";
+import { useClearSelection } from "@helpers/useClearSelection";
 
 const getGeographyLabel = (geographyId: string | null): string | null => {
   switch (geographyId) {
@@ -23,6 +24,8 @@ export const GeographyInfo = () => {
 
   const pumaInfo = usePumaInfo(geoid);
 
+  const clearSelection = useClearSelection();
+
   return (
     <Box paddingBottom="2rem">
       <Heading fontSize=".8125rem" fontWeight={500} color="teal.600">
@@ -39,7 +42,12 @@ export const GeographyInfo = () => {
       >
         {pumaInfo?.districts ? pumaInfo.districts : ""}
       </Heading>
-      <Button rightIcon={<CloseIcon />} variant="outline" size="xs">
+      <Button
+        rightIcon={<CloseIcon />}
+        variant="outline"
+        size="xs"
+        onClick={clearSelection}
+      >
         Clear Selection
       </Button>
     </Box>

--- a/src/components/GeographyInfo/GeographyInfo.tsx
+++ b/src/components/GeographyInfo/GeographyInfo.tsx
@@ -1,0 +1,47 @@
+import { CloseIcon } from "@chakra-ui/icons";
+import { Heading, Box, Button } from "@chakra-ui/react";
+import { useMapSubrouteInfo } from "@hooks/useMapSubrouteInfo";
+import { usePumaInfo } from "@hooks/usePumaInfo";
+
+const getGeographyLabel = (geographyId: string | null): string | null => {
+  switch (geographyId) {
+    case "borough":
+      return "Borough";
+    case "district":
+      return "Community District";
+    case "citywide":
+      return "City";
+  }
+
+  return null;
+};
+
+export const GeographyInfo = () => {
+  const { geography, geoid } = useMapSubrouteInfo();
+
+  const geographyLabel = getGeographyLabel(geography);
+
+  const pumaInfo = usePumaInfo(geoid);
+
+  return (
+    <Box paddingBottom="2rem">
+      <Heading fontSize=".8125rem" fontWeight={500} color="teal.600">
+        {geographyLabel} {geoid}
+      </Heading>
+      <Heading as="h1" fontSize="1.5625rem" fontWeight={700} padding=".5rem 0">
+        {pumaInfo?.neighborhoods ? pumaInfo.neighborhoods : ""}
+      </Heading>
+      <Heading
+        as="h3"
+        fontSize=".8125rem"
+        fontWeight={400}
+        paddingBottom=".25rem"
+      >
+        {pumaInfo?.districts ? pumaInfo.districts : ""}
+      </Heading>
+      <Button rightIcon={<CloseIcon />} variant="outline" size="xs">
+        Clear Selection
+      </Button>
+    </Box>
+  );
+};

--- a/src/components/GeographyInfo/GeographyInfo.tsx
+++ b/src/components/GeographyInfo/GeographyInfo.tsx
@@ -5,7 +5,7 @@ import { usePumaInfo } from "@hooks/usePumaInfo";
 import { useClearSelection } from "@helpers/useClearSelection";
 
 export const GeographyInfo = () => {
-  const { geography, geoid } = useMapSubrouteInfo();
+  const { view, geography, geoid } = useMapSubrouteInfo();
 
   const pumaInfo = usePumaInfo(geoid);
 
@@ -23,13 +23,16 @@ export const GeographyInfo = () => {
     case "citywide":
       primaryHeading = "New York City";
       break;
+    case "nta":
+      primaryHeading = "QN68 - Queensbridge Ravenswood Long Island City";
+      break;
     default:
       break;
   }
 
   return (
     <Box paddingBottom="2rem">
-      {geography === "district" && (
+      {view === "datatool" && geography === "district" && (
         <Heading fontSize=".8125rem" fontWeight={500} color="teal.600">
           PUMA {geoid}
         </Heading>
@@ -43,14 +46,16 @@ export const GeographyInfo = () => {
       >
         {primaryHeading}
       </Heading>
-      <Heading
-        as="h3"
-        fontSize=".8125rem"
-        fontWeight={400}
-        paddingBottom=".25rem"
-      >
-        {pumaInfo?.districts ? pumaInfo.districts : ""}
-      </Heading>
+      {view === "datatool" && (
+        <Heading
+          as="h3"
+          fontSize=".8125rem"
+          fontWeight={400}
+          paddingBottom=".25rem"
+        >
+          {pumaInfo?.districts ? pumaInfo.districts : ""}
+        </Heading>
+      )}
       <Button
         rightIcon={<CloseIcon />}
         variant="outline"

--- a/src/components/GeographyInfo/GeographyInfo.tsx
+++ b/src/components/GeographyInfo/GeographyInfo.tsx
@@ -4,35 +4,38 @@ import { useMapSubrouteInfo } from "@hooks/useMapSubrouteInfo";
 import { usePumaInfo } from "@hooks/usePumaInfo";
 import { useClearSelection } from "@helpers/useClearSelection";
 
-const getGeographyLabel = (geographyId: string | null): string | null => {
-  switch (geographyId) {
-    case "borough":
-      return "Borough";
-    case "district":
-      return "Community District";
-    case "citywide":
-      return "City";
-  }
-
-  return null;
-};
-
 export const GeographyInfo = () => {
   const { geography, geoid } = useMapSubrouteInfo();
-
-  const geographyLabel = getGeographyLabel(geography);
 
   const pumaInfo = usePumaInfo(geoid);
 
   const clearSelection = useClearSelection();
 
+  let primaryHeading = "";
+
+  switch (geography) {
+    case "district":
+      primaryHeading = pumaInfo?.neighborhoods ? pumaInfo.neighborhoods : "";
+      break;
+    case "borough":
+      primaryHeading = `${geoid}`;
+      break;
+    case "citywide":
+      primaryHeading = "New York City";
+      break;
+    default:
+      break;
+  }
+
   return (
     <Box paddingBottom="2rem">
-      <Heading fontSize=".8125rem" fontWeight={500} color="teal.600">
-        {geographyLabel} {geoid}
-      </Heading>
+      {geography === "district" && (
+        <Heading fontSize=".8125rem" fontWeight={500} color="teal.600">
+          PUMA {geoid}
+        </Heading>
+      )}
       <Heading as="h1" fontSize="1.5625rem" fontWeight={700} padding=".5rem 0">
-        {pumaInfo?.neighborhoods ? pumaInfo.neighborhoods : ""}
+        {primaryHeading}
       </Heading>
       <Heading
         as="h3"

--- a/src/components/GeographyInfo/GeographyInfo.tsx
+++ b/src/components/GeographyInfo/GeographyInfo.tsx
@@ -34,7 +34,13 @@ export const GeographyInfo = () => {
           PUMA {geoid}
         </Heading>
       )}
-      <Heading as="h1" fontSize="1.5625rem" fontWeight={700} padding=".5rem 0">
+      <Heading
+        as="h1"
+        fontSize="1.5625rem"
+        fontWeight={700}
+        padding=".5rem 0"
+        isTruncated
+      >
         {primaryHeading}
       </Heading>
       <Heading

--- a/src/components/GeographyInfo/index.ts
+++ b/src/components/GeographyInfo/index.ts
@@ -1,0 +1,1 @@
+export * from "./GeographyInfo";

--- a/src/components/Map/MobileDrawer.tsx
+++ b/src/components/Map/MobileDrawer.tsx
@@ -1,13 +1,16 @@
 import { useState } from "react";
-import { Heading, Box, Center, IconButton, Flex } from "@chakra-ui/react";
+import { Box, IconButton, Flex } from "@chakra-ui/react";
 import { ChevronUpIcon, ChevronDownIcon } from "@chakra-ui/icons";
 
 interface MobileDrawerProps {
-  title: string | null;
   children?: React.ReactNode;
 }
 
-export const MobileDrawer = ({ title, children }: MobileDrawerProps) => {
+// It is the responsibility of MobileDrawer's children to make sure
+// that content is not occluded by the open/close toggle at the top right.
+// The button is 3rem x 3rem. The MobileDrawer also has 1rem padding around the sides
+// One solution is to add 2rem right padding for content at the top of the MobileDrawer.
+export const MobileDrawer = ({ children }: MobileDrawerProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
@@ -20,59 +23,62 @@ export const MobileDrawer = ({ title, children }: MobileDrawerProps) => {
       width="100%"
       position="fixed"
       top={isOpen ? "6rem" : "100vh"}
-      marginTop={isOpen ? "auto" : "-7.875rem"}
+      marginTop={isOpen ? "auto" : "-9rem"}
       paddingBottom="6rem"
       left="0"
       zIndex="900"
       bg="white"
       data-cy="mobileDrawer"
     >
-      <Flex direction="column" height="100%">
-        <Flex
-          direction="row"
-          justifyContent="space-between"
-          height="4.125rem"
-          flex="shrink"
+      <Flex direction="column" height="100%" position="relative">
+        <Box
+          position="absolute"
+          width="100%"
+          top={0}
+          cursor="pointer"
+          zIndex="999"
+          align="right"
+          bg="rgba(0,0,0,0)"
           onClick={() => {
             setIsOpen(!isOpen);
           }}
-          cursor="pointer"
         >
-          <Box height="100%" p="0 1rem">
-            <Center h="100%">
-              <Heading>{title}</Heading>
-            </Center>
-          </Box>
+          {isOpen ? (
+            <IconButton
+              variant="ghost"
+              size="lg"
+              fontSize="1.25rem"
+              bg="rgba(0,0,0,0)"
+              icon={<ChevronDownIcon />}
+              onClick={() => {
+                setIsOpen(!isOpen);
+              }}
+              aria-label="Toggle Drawer"
+              data-cy="closeMobileDrawer"
+            />
+          ) : (
+            <IconButton
+              variant="ghost"
+              size="lg"
+              fontSize="1.25rem"
+              bg="rgba(0,0,0,0)"
+              icon={<ChevronUpIcon />}
+              aria-label="Toggle Drawer"
+              data-cy="openMobileDrawer"
+            />
+          )}
+        </Box>
 
-          <Box flex="shrink">
-            <Center h="100%" w="100%">
-              {isOpen ? (
-                <IconButton
-                  variant="ghost"
-                  size="lg"
-                  aria-label="Toggle Drawer"
-                  fontSize="20px"
-                  icon={<ChevronDownIcon />}
-                  onClick={() => {
-                    setIsOpen(!isOpen);
-                  }}
-                  data-cy="closeMobileDrawer"
-                />
-              ) : (
-                <IconButton
-                  variant="ghost"
-                  size="lg"
-                  aria-label="Toggle Drawer"
-                  fontSize="20px"
-                  icon={<ChevronUpIcon />}
-                  data-cy="openMobileDrawer"
-                />
-              )}
-            </Center>
-          </Box>
-        </Flex>
-
-        <Box flex="auto" overflow="scroll" p="0 1rem">
+        <Box
+          flex="auto"
+          overflow="scroll"
+          p="1rem"
+          css={{
+            "&::-webkit-scrollbar": {
+              display: "none",
+            },
+          }}
+        >
           {children}
         </Box>
       </Flex>

--- a/src/components/Map/ViewToggle.tsx
+++ b/src/components/Map/ViewToggle.tsx
@@ -1,22 +1,21 @@
 import { Flex, BoxProps, Button } from "@chakra-ui/react";
 import { ToggleButtonGroup } from "@components/ToggleButtonGroup";
+import { useMapSubrouteInfo } from "@hooks/useMapSubrouteInfo";
 
 interface ViewToggleProps extends BoxProps {
   onDataToolClick: () => void;
   onDriClick: () => void;
-  view: string | null;
-  showOnMobile: boolean;
 }
 
 export const ViewToggle = ({
   onDataToolClick,
   onDriClick,
-  view,
-  showOnMobile,
 }: ViewToggleProps) => {
+  const { view, geography, geoid } = useMapSubrouteInfo();
+
   return (
     <>
-      {showOnMobile && (
+      {!geoid && geography !== "citywide" && (
         <Flex
           display={{
             base: "flex",

--- a/src/components/SidebarContent/SidebarContent.tsx
+++ b/src/components/SidebarContent/SidebarContent.tsx
@@ -8,11 +8,11 @@ import { useMapSubrouteInfo } from "@hooks/useMapSubrouteInfo";
 import { useClearSelection } from "@helpers/useClearSelection";
 
 export const SidebarContent = () => {
-  const { view, geoid } = useMapSubrouteInfo();
+  const { view, geography, geoid } = useMapSubrouteInfo();
 
   const clearSelection = useClearSelection();
 
-  if (geoid != null) {
+  if (geoid != null || geography === "citywide") {
     if (view === "dri") {
       return (
         <>
@@ -41,6 +41,7 @@ export const SidebarContent = () => {
       );
     }
   }
+
   return (
     <>
       <Box height="100%" justify="space-between">

--- a/src/components/SidebarContent/SidebarContent.tsx
+++ b/src/components/SidebarContent/SidebarContent.tsx
@@ -1,46 +1,22 @@
 import React from "react";
 import { Heading, Box, Button } from "@chakra-ui/react";
 import { CloseIcon } from "@chakra-ui/icons";
+import { GeographyInfo } from "@components/GeographyInfo";
 import WelcomeContent from "@components/WelcomeContent";
 import WelcomeFooter from "@components/WelcomeFooter";
-import { useView } from "@hooks/useView";
 import { useRouter } from "next/router";
 import { useMapSubrouteInfo } from "@hooks/useMapSubrouteInfo";
 
-const getGeographyLabel = (geographyId: string | null): string | null => {
-  switch (geographyId) {
-    case "borough":
-      return "Borough";
-    case "district":
-      return "Community District";
-    case "citywide":
-      return "City";
-  }
-
-  return null;
-};
-
-interface SidebarContentProps {
-  isGeographySelected: boolean;
-}
-
-export const SidebarContent = ({
-  isGeographySelected,
-}: SidebarContentProps) => {
-  const view = useView();
+export const SidebarContent = () => {
   const router = useRouter();
-  const { subroutes } = router.query;
-  const [viewParam, geographyParam] = subroutes ? subroutes : [null, null];
 
-  const { geography, geoid } = useMapSubrouteInfo();
-
-  const geographyLabel = getGeographyLabel(geography);
+  const { view, geography, geoid } = useMapSubrouteInfo();
 
   const clearSelection = () => {
-    router.push(`/map/${viewParam}/${geographyParam}/`);
+    router.push(`/map/${view}/${geography}/`);
   };
 
-  if (isGeographySelected) {
+  if (geoid != null) {
     if (view === "dri") {
       return (
         <>
@@ -63,35 +39,7 @@ export const SidebarContent = ({
     } else {
       return (
         <>
-          <Box paddingBottom="2rem">
-            <Heading fontSize=".8125rem" fontWeight={500} color="teal.600">
-              {geographyLabel} {geoid}
-            </Heading>
-            <Heading
-              as="h1"
-              fontSize="1.5625rem"
-              fontWeight={700}
-              padding=".5rem 0"
-            >
-              Sunnyside &amp; Woodside
-            </Heading>
-            <Heading
-              as="h3"
-              fontSize=".8125rem"
-              fontWeight={400}
-              paddingBottom=".25rem"
-            >
-              Approx. Queens Community District 2
-            </Heading>
-            <Button
-              rightIcon={<CloseIcon />}
-              variant="outline"
-              size="xs"
-              onClick={clearSelection}
-            >
-              Clear Selection
-            </Button>
-          </Box>
+          <GeographyInfo />
           <hr />
         </>
       );

--- a/src/components/SidebarContent/SidebarContent.tsx
+++ b/src/components/SidebarContent/SidebarContent.tsx
@@ -45,8 +45,6 @@ export const SidebarContent = () => {
   return (
     <>
       <Box height="100%" justify="space-between">
-        <Heading>Welcome!</Heading>
-        <br />
         <WelcomeContent />
       </Box>
       <Box>

--- a/src/components/SidebarContent/SidebarContent.tsx
+++ b/src/components/SidebarContent/SidebarContent.tsx
@@ -4,17 +4,13 @@ import { CloseIcon } from "@chakra-ui/icons";
 import { GeographyInfo } from "@components/GeographyInfo";
 import WelcomeContent from "@components/WelcomeContent";
 import WelcomeFooter from "@components/WelcomeFooter";
-import { useRouter } from "next/router";
 import { useMapSubrouteInfo } from "@hooks/useMapSubrouteInfo";
+import { useClearSelection } from "@helpers/useClearSelection";
 
 export const SidebarContent = () => {
-  const router = useRouter();
+  const { view, geoid } = useMapSubrouteInfo();
 
-  const { view, geography, geoid } = useMapSubrouteInfo();
-
-  const clearSelection = () => {
-    router.push(`/map/${view}/${geography}/`);
-  };
+  const clearSelection = useClearSelection();
 
   if (geoid != null) {
     if (view === "dri") {

--- a/src/components/SidebarContent/SidebarContent.tsx
+++ b/src/components/SidebarContent/SidebarContent.tsx
@@ -1,45 +1,20 @@
 import React from "react";
-import { Heading, Box, Button } from "@chakra-ui/react";
-import { CloseIcon } from "@chakra-ui/icons";
+import { Box } from "@chakra-ui/react";
 import { GeographyInfo } from "@components/GeographyInfo";
 import WelcomeContent from "@components/WelcomeContent";
 import WelcomeFooter from "@components/WelcomeFooter";
 import { useMapSubrouteInfo } from "@hooks/useMapSubrouteInfo";
-import { useClearSelection } from "@helpers/useClearSelection";
 
 export const SidebarContent = () => {
-  const { view, geography, geoid } = useMapSubrouteInfo();
-
-  const clearSelection = useClearSelection();
+  const { geography, geoid } = useMapSubrouteInfo();
 
   if (geoid != null || geography === "citywide") {
-    if (view === "dri") {
-      return (
-        <>
-          <Box paddingBottom="2rem">
-            <Heading as="h1" fontSize="1.5625rem" fontWeight={700}>
-              QN68 - Queensbridge Ravenswood Long Island City
-            </Heading>
-            <Button
-              rightIcon={<CloseIcon />}
-              variant="outline"
-              size="xs"
-              onClick={clearSelection}
-            >
-              Clear Selection
-            </Button>
-          </Box>
-          <hr />
-        </>
-      );
-    } else {
-      return (
-        <>
-          <GeographyInfo />
-          <hr />
-        </>
-      );
-    }
+    return (
+      <>
+        <GeographyInfo />
+        <hr />
+      </>
+    );
   }
 
   return (

--- a/src/components/WelcomeContent.tsx
+++ b/src/components/WelcomeContent.tsx
@@ -1,4 +1,4 @@
-import { Text, Link } from "@chakra-ui/react";
+import { Heading, Text, Link } from "@chakra-ui/react";
 import { useView } from "@hooks/useView";
 
 const WelcomeContent = () => {
@@ -7,6 +7,9 @@ const WelcomeContent = () => {
   if (view === "datatool") {
     return (
       <>
+        <Heading>Welcome!</Heading>
+        <br />
+
         <Text>You don&apos;t have anything selected yet.</Text>
         <br />
         <Text>

--- a/src/components/WelcomeContent.tsx
+++ b/src/components/WelcomeContent.tsx
@@ -32,6 +32,9 @@ const WelcomeContent = () => {
   if (view === "dri") {
     return (
       <>
+        <Heading>Welcome!</Heading>
+        <br />
+
         <Text>You don&apos;t have anything selected yet.</Text>
         <br />
         <Text>

--- a/src/data/pumas.json
+++ b/src/data/pumas.json
@@ -1,0 +1,277 @@
+{
+  "3701": {
+    "id": "3701",
+    "neighborhoods": "Riverdale, Fieldston & Kingsbridge",
+    "districts": "Approx. Bronx CD 8"
+  },
+  "3702": {
+    "id": "3702",
+    "neighborhoods": "Wakefield, Williamsbridge & Woodlawn",
+    "districts": "Approx. Bronx CD 12"
+  },
+  "3703": {
+    "id": "3703",
+    "neighborhoods": "Co-op City, Pelham Bay & Schuylerville",
+    "districts": "Approx. Bronx CD 10"
+  },
+  "3704": {
+    "id": "3704",
+    "neighborhoods": "Pelham Parkway, Morris Park & Laconia",
+    "districts": "Approx. Bronx CD 11"
+  },
+  "3705": {
+    "id": "3705",
+    "neighborhoods": "Belmont, Crotona Park East & East Tremont",
+    "districts": "Approx. Bronx CD 3 & 6"
+  },
+  "3706": {
+    "id": "3706",
+    "neighborhoods": "Bedford Park, Fordham North & Norwood",
+    "districts": "Approx. Bronx CD 7"
+  },
+  "3707": {
+    "id": "3707",
+    "neighborhoods": "Morris Heights, Fordham South & Mount Hope",
+    "districts": "Approx. Bronx CD 5"
+  },
+  "3708": {
+    "id": "3708",
+    "neighborhoods": "Concourse, Highbridge & Mount Eden",
+    "districts": "Approx. Bronx CD 4"
+  },
+  "3709": {
+    "id": "3709",
+    "neighborhoods": "Castle Hill, Clason Point & Parkchester",
+    "districts": "Approx. Bronx CD 9"
+  },
+  "3710": {
+    "id": "3710",
+    "neighborhoods": "Hunts Point, Longwood & Melrose",
+    "districts": "Approx. Bronx CD 1 & 2"
+  },
+  "4001": {
+    "id": "4001",
+    "neighborhoods": "Greenpoint & Williamsburg",
+    "districts": "Approx. Brooklyn CD 1"
+  },
+  "4002": {
+    "id": "4002",
+    "neighborhoods": "Bushwick",
+    "districts": "Approx. Brooklyn CD 4"
+  },
+  "4003": {
+    "id": "4003",
+    "neighborhoods": "Bedford-Stuyvesant",
+    "districts": "Approx. Brooklyn CD 3"
+  },
+  "4004": {
+    "id": "4004",
+    "neighborhoods": "Brooklyn Heights & Fort Greene",
+    "districts": "Approx. Brooklyn CD 2"
+  },
+  "4005": {
+    "id": "4005",
+    "neighborhoods": "Park Slope, Carroll Gardens & Red Hook",
+    "districts": "Approx. Brooklyn CD 6"
+  },
+  "4006": {
+    "id": "4006",
+    "neighborhoods": "Crown Heights North & Prospect Heights",
+    "districts": "Approx. Brooklyn CD 8"
+  },
+  "4007": {
+    "id": "4007",
+    "neighborhoods": "Brownsville & Ocean Hill",
+    "districts": "Approx. Brooklyn CD 16"
+  },
+  "4008": {
+    "id": "4008",
+    "neighborhoods": "East New York & Starrett City",
+    "districts": "Approx. Brooklyn CD 5"
+  },
+  "4009": {
+    "id": "4009",
+    "neighborhoods": "Canarsie & Flatlands",
+    "districts": "Approx. Brooklyn CD 18"
+  },
+  "4010": {
+    "id": "4010",
+    "neighborhoods": "East Flatbush, Farragut & Rugby",
+    "districts": "Approx. Brooklyn CD 17"
+  },
+  "4011": {
+    "id": "4011",
+    "neighborhoods": "Crown Heights South, Prospect Lefferts & Wingate",
+    "districts": "Approx. Brooklyn CD 9"
+  },
+  "4012": {
+    "id": "4012",
+    "neighborhoods": "Sunset Park & Windsor Terrace",
+    "districts": "Approx. Brooklyn CD 7"
+  },
+  "4013": {
+    "id": "4013",
+    "neighborhoods": "Bay Ridge & Dyker Heights",
+    "districts": "Approx. Brooklyn CD 10"
+  },
+  "4014": {
+    "id": "4014",
+    "neighborhoods": "Borough Park, Kensington & Ocean Parkway",
+    "districts": "Approx. Brooklyn CD 12"
+  },
+  "4015": {
+    "id": "4015",
+    "neighborhoods": "Flatbush & Midwood",
+    "districts": "Approx. Brooklyn CD 14"
+  },
+  "4016": {
+    "id": "4016",
+    "neighborhoods": "Sheepshead Bay, Gerritsen Beach & Homecrest",
+    "districts": "Approx. Brooklyn CD 15"
+  },
+  "4017": {
+    "id": "4017",
+    "neighborhoods": "Bensonhurst & Bath Beach",
+    "districts": "Approx. Brooklyn CD 11"
+  },
+  "4018": {
+    "id": "4018",
+    "neighborhoods": "Brighton Beach & Coney Island",
+    "districts": "Approx. Brooklyn CD 13"
+  },
+  "3801": {
+    "id": "3801",
+    "neighborhoods": "Washington Heights, Inwood & Marble Hill",
+    "districts": "Approx. Manhattan CD 12"
+  },
+  "3802": {
+    "id": "3802",
+    "neighborhoods": "Hamilton Heights, Manhattanville & West Harlem",
+    "districts": "Approx. Manhattan CD 9"
+  },
+  "3803": {
+    "id": "3803",
+    "neighborhoods": "Central Harlem",
+    "districts": "Approx. Manhattan CD 10"
+  },
+  "3804": {
+    "id": "3804",
+    "neighborhoods": "East Harlem",
+    "districts": "Approx. Manhattan CD 11"
+  },
+  "3805": {
+    "id": "3805",
+    "neighborhoods": "Upper East Side",
+    "districts": "Approx. Manhattan CD 8"
+  },
+  "3806": {
+    "id": "3806",
+    "neighborhoods": "Upper West Side & West Side",
+    "districts": "Approx. Manhattan CD 7"
+  },
+  "3807": {
+    "id": "3807",
+    "neighborhoods": "Chelsea, Clinton & Midtown Business District",
+    "districts": "Approx. Manhattan CD 4 & 5"
+  },
+  "3808": {
+    "id": "3808",
+    "neighborhoods": "Murray Hill, Gramercy & Stuyvesant Town",
+    "districts": "Approx. Manhattan CD 6"
+  },
+  "3809": {
+    "id": "3809",
+    "neighborhoods": "Chinatown & Lower East Side",
+    "districts": "Approx. Manhattan CD 3"
+  },
+  "3810": {
+    "id": "3810",
+    "neighborhoods": "Battery Park City, Greenwich Village & Soho",
+    "districts": "Approx. Manhattan CD 1 & 2"
+  },
+  "4101": {
+    "id": "4101",
+    "neighborhoods": "Astoria & Long Island City",
+    "districts": "Approx. Queens CD 1"
+  },
+  "4102": {
+    "id": "4102",
+    "neighborhoods": "Jackson Heights & North Corona",
+    "districts": "Approx. Queens CD 3"
+  },
+  "4103": {
+    "id": "4103",
+    "neighborhoods": "Flushing, Murray Hill & Whitestone",
+    "districts": "Approx. Queens CD 7"
+  },
+  "4104": {
+    "id": "4104",
+    "neighborhoods": "Bayside, Douglaston & Little Neck",
+    "districts": "Approx. Queens CD 11"
+  },
+  "4105": {
+    "id": "4105",
+    "neighborhoods": "Queens Village, Cambria Heights & Rosedale",
+    "districts": "Approx. Queens CD 13"
+  },
+  "4106": {
+    "id": "4106",
+    "neighborhoods": "Briarwood, Fresh Meadows & Hillcrest",
+    "districts": "Approx. Queens CD 8"
+  },
+  "4107": {
+    "id": "4107",
+    "neighborhoods": "Elmhurst & South Corona",
+    "districts": "Approx. Queens CD 4"
+  },
+  "4108": {
+    "id": "4108",
+    "neighborhoods": "Forest Hills & Rego Park",
+    "districts": "Approx. Queens CD 6"
+  },
+  "4109": {
+    "id": "4109",
+    "neighborhoods": "Sunnyside & Woodside",
+    "districts": "Approx. Queens CD 2"
+  },
+  "4110": {
+    "id": "4110",
+    "neighborhoods": "Ridgewood, Glendale & Middle Village",
+    "districts": "Approx. Queens CD 5"
+  },
+  "4111": {
+    "id": "4111",
+    "neighborhoods": "Richmond Hill & Woodhaven",
+    "districts": "Approx. Queens CD 9"
+  },
+  "4112": {
+    "id": "4112",
+    "neighborhoods": "Jamaica, Hollis & St. Albans",
+    "districts": "Approx. Queens CD 12"
+  },
+  "4113": {
+    "id": "4113",
+    "neighborhoods": "Howard Beach & Ozone Park",
+    "districts": "Approx. Queens CD 10"
+  },
+  "4114": {
+    "id": "4114",
+    "neighborhoods": "Far Rockaway, Breezy Point & Broad Channel",
+    "districts": "Approx. Queens CD 14"
+  },
+  "3901": {
+    "id": "3901",
+    "neighborhoods": "Tottenville, Great Kills & Annadale",
+    "districts": "Approx. Staten Island CD 3"
+  },
+  "3902": {
+    "id": "3902",
+    "neighborhoods": "New Springville & South Beach",
+    "districts": "Approx. Staten Island CD 2"
+  },
+  "3903": {
+    "id": "3903",
+    "neighborhoods": "Port Richmond, Stapleton & Mariner's Harbor",
+    "districts": "Approx. Staten Island CD 1"
+  }
+}

--- a/src/helpers/hasOwnProperty.ts
+++ b/src/helpers/hasOwnProperty.ts
@@ -1,0 +1,5 @@
+// This function helps avoid TypeScript errors when using type string to index into an Object
+// https://fettblog.eu/typescript-hasownproperty/
+export function hasOwnProperty<T>(obj: T, key: PropertyKey): key is keyof T {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}

--- a/src/helpers/useClearSelection.ts
+++ b/src/helpers/useClearSelection.ts
@@ -1,0 +1,11 @@
+import { useRouter } from "next/router";
+import { useMapSubrouteInfo } from "@hooks/useMapSubrouteInfo";
+
+export function useClearSelection() {
+  const router = useRouter();
+  const { view, geography } = useMapSubrouteInfo();
+
+  return () => {
+    router.push(`/map/${view}/${geography}/`);
+  };
+}

--- a/src/hooks/useIndicatorRecord/useIndicatorRecord.ts
+++ b/src/hooks/useIndicatorRecord/useIndicatorRecord.ts
@@ -1,16 +1,10 @@
 import ntas from "@data/ntas.json";
 import { NtaIndicatorRecord } from "@type/Nta";
+import { hasOwnProperty } from "@helpers/hasOwnProperty";
 
 export const useIndicatorRecord = (
   geoid: string | null
 ): NtaIndicatorRecord | null => {
-  // This function is a helper that makes a type-safe wrapper for Object.hasOwnProperty
-  // Normally we would move this somewhere sharable but since most of this code will likely only
-  // be temporary, it's fine for now
-  function hasOwnProperty<T>(obj: T, key: PropertyKey): key is keyof T {
-    return Object.prototype.hasOwnProperty.call(obj, key);
-  }
-
   if (!geoid || !hasOwnProperty(ntas, geoid)) return null;
 
   return ntas[geoid];

--- a/src/hooks/usePumaInfo/index.ts
+++ b/src/hooks/usePumaInfo/index.ts
@@ -1,0 +1,1 @@
+export * from "./usePumaInfo";

--- a/src/hooks/usePumaInfo/usePumaInfo.ts
+++ b/src/hooks/usePumaInfo/usePumaInfo.ts
@@ -1,0 +1,10 @@
+import pumas from "@data/pumas.json";
+import { hasOwnProperty } from "@helpers/hasOwnProperty";
+
+export type pumaInfo = typeof pumas["3701"];
+
+export const usePumaInfo = (pumaId: string | null): pumaInfo | null => {
+  if (!pumaId || !hasOwnProperty(pumas, pumaId)) return null;
+
+  return pumas[pumaId];
+};

--- a/src/pages/map/[[...subroutes]].tsx
+++ b/src/pages/map/[[...subroutes]].tsx
@@ -3,7 +3,6 @@ import { GetServerSideProps } from "next";
 import { useRef, useState } from "react";
 import { Box, Flex } from "@chakra-ui/react";
 import { useSelectedLayer } from "@hooks/useSelectedLayer";
-import { useIndicatorRecord } from "@hooks/useIndicatorRecord";
 import { Map, MobileDrawer, ViewToggle } from "@components/Map";
 import { GeographySelect as DataToolGeographySelect } from "@components/Map/DataTool";
 import { SidebarContent } from "@components/SidebarContent";
@@ -55,8 +54,6 @@ const MapPage = ({ initialRouteParams }: MapPageProps) => {
   const { view, geography, geoid } = useMapSubrouteInfo();
 
   const layers = useSelectedLayer(view, geography);
-
-  const indicatorRecord = useIndicatorRecord(geoid);
 
   const mapContainer = useRef<HTMLDivElement>(null);
 
@@ -117,7 +114,7 @@ const MapPage = ({ initialRouteParams }: MapPageProps) => {
         <SidebarContent />
       </Flex>
 
-      <MobileDrawer title={indicatorRecord ? geoid : "Welcome!"}>
+      <MobileDrawer>
         <DrawerContent />
       </MobileDrawer>
 
@@ -126,8 +123,6 @@ const MapPage = ({ initialRouteParams }: MapPageProps) => {
           <ViewToggle
             onDataToolClick={onDataToolClick}
             onDriClick={onDriClick}
-            view={view}
-            showOnMobile={!geoid}
           />
 
           {view === "datatool" && (

--- a/src/pages/map/[[...subroutes]].tsx
+++ b/src/pages/map/[[...subroutes]].tsx
@@ -114,7 +114,7 @@ const MapPage = ({ initialRouteParams }: MapPageProps) => {
         zIndex="999"
         data-cy="desktopSidebar"
       >
-        <SidebarContent isGeographySelected={!!geoid} />
+        <SidebarContent />
       </Flex>
 
       <MobileDrawer title={indicatorRecord ? geoid : "Welcome!"}>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,8 @@
       "@components/*": ["components/*"],
       "@data/*": ["data/*"],
       "@hooks/*": ["hooks/*"],
-      "@type/*": ["type/*"]
+      "@type/*": ["type/*"],
+      "@helpers/*": ["helpers/*"]
     }
   },
   "include": [


### PR DESCRIPTION
### Summary
 - Uses geography and  geoid information from the route to render correct Data Tool geography information in the Sidebar and Mobile Drawer. The new component responsible for this rendering is `GeographyInfo`
 - District Geo Info is loaded from a static file (pumas.json)
 - It also consolidates the DRI geography information template into the `GeographyInfo` component, since it's the same as the other.
 - Removes redundant if/else `view` conditions  
 - A future PR still needs to add DRI Geo Info to Mobile
 - Centralizes  ClearSelection
 - Refactors a lot of functions to make use of `useMapSubrouteInfo()`

Fixes [AB#6877](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/6877) [AB#6883](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/6883)

<img width="402" alt="image" src="https://user-images.githubusercontent.com/3311663/155388474-b6b8f90f-8d6d-41e9-b024-b6850e60c646.png">
