### PR TITLE
6875 Fix bug with shrinking sidebar and clean up table styles

### DIFF
--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -27,28 +27,33 @@ export const DataTable = ({ children }: DataTableProps) => {
 
   return (
     <DataTableContext.Provider value={{ isOpen, onToggle }}>
-      <Box marginLeft={{ base: "0.75rem", md: 0 }} overflowX={"scroll"}>
+      <Box
+        flexShrink={{ base: 1, md: 0 }}
+        overflowX={{ base: "auto", md: "hidden" }}
+      >
         <Table
           variant="striped"
           sx={{
             paddingRight: { base: 3, md: 0 },
             display: "block",
-            overflowX: "auto",
+            overflowX: { base: "auto", md: "hidden" },
             borderCollapse: "initial",
             borderSpacing: 0,
             fontSize: "0.875rem",
             whiteSpace: "nowrap",
+            tableLayout: "fixed",
+
             "thead tr": {
               th: {
-                minW: "calc((100vw - 26px) / 3)",
-                maxW: "calc((100vw - 26px) / 3)",
+                minW: { base: "calc((100vw - 26px) / 3)", md: "8rem" },
+                maxW: { base: "calc((100vw - 26px) / 3)", md: "8rem" },
                 whiteSpace: "normal",
               },
             },
             tbody: {
               td: {
-                minW: "calc((100vw - 26px) / 3)",
-                maxW: "calc((100vw - 26px) / 3)",
+                minW: { base: "calc((100vw - 26px) / 3)", md: "8rem" },
+                maxW: { base: "calc((100vw - 26px) / 3)", md: "8rem" },
                 whiteSpace: "normal",
                 px: "1.5rem",
               },
@@ -57,7 +62,10 @@ export const DataTable = ({ children }: DataTableProps) => {
                   borderBottomLeftRadius: "0.75rem",
                 },
                 "td:last-of-type": {
-                  borderBottomRightRadius: "0.75rem",
+                  borderBottomRightRadius: {
+                    base: "0.75rem",
+                    md: "0rem",
+                  },
                 },
               },
             },

--- a/src/components/DataTable/DataTableHead.tsx
+++ b/src/components/DataTable/DataTableHead.tsx
@@ -21,8 +21,14 @@ export const DataTableHead = ({
         <Th
           onClick={onToggle}
           colSpan={colSpan}
-          borderTopLeftRadius="0.75rem"
-          borderTopRightRadius="0.75rem"
+          borderTopLeftRadius={{
+            base: "0.75rem",
+            md: "0rem",
+          }}
+          borderTopRightRadius={{
+            base: "0.75rem",
+            md: "0rem",
+          }}
           borderBottomLeftRadius={{
             base: isOpen ? "0rem" : "0.75rem",
             md: "0rem",

--- a/src/pages/data/[geography]/[geoid]/[category].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category].tsx
@@ -58,6 +58,7 @@ const DataExplorerNav = () => {
 
   return (
     <Flex
+      flexShrink={"0"}
       direction={"column"}
       height={{ base: "auto", md: "full" }}
       width={{
@@ -229,8 +230,8 @@ const DataPage = ({ initialRouteParams }: DataPageProps) => {
       gridGap={{ base: "1.5rem", md: "0rem" }}
     >
       <DataExplorerNav />
-      <Box flexGrow={1}>
-        <Box>Subgroup switcher</Box>
+      <Box flexGrow={1} overflowX={"hidden"}>
+        <Box>Subgroup switcher can go here</Box>
         <Divider display={{ base: "none", md: "block" }} color={"gray.300"} />
         <FormControl mb={4} display="flex" alignItems="center">
           <Switch
@@ -247,6 +248,7 @@ const DataPage = ({ initialRouteParams }: DataPageProps) => {
         <Flex
           direction={{ base: "column", md: "row" }}
           gridGap={{ base: 3, md: 0 }}
+          overflowX={"auto"}
         >
           <EstimateTable
             data={testData}

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -30,6 +30,7 @@ const theme = extendTheme({
             borderColor: "gray.300",
             textTransform: "capitalize",
             textAlign: "center",
+            py: "0.75rem",
           },
           tbody: {
             width: "100%",


### PR DESCRIPTION
### Summary
This is the first in a few PRs for handling the desktop styling for the Data Explorer page. This PR just cleans up some of the basic page layout so that another engineer can pick up working on the subgroup dropdown

#### Tasks/Bug Numbers
 - Fixes [AB#6875](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/6875)
