### PR TITLE
Task/6824 stack desktop toggles

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -44,8 +44,8 @@ export const Map = ({ layers, parent }: MapProps) => {
       <Box
         position="absolute"
         top={{
-          base: view === "datatool" ? "5rem" : "1.3rem",
-          md: "5rem",
+          base: view === "datatool" ? "4.5rem" : "1.3rem",
+          md: "8rem",
         }}
         left="2.1875rem"
       >

--- a/src/components/Map/ViewToggle.tsx
+++ b/src/components/Map/ViewToggle.tsx
@@ -70,8 +70,8 @@ export const ViewToggle = ({
 
       <ToggleButtonGroup
         position="absolute"
-        top={5}
-        left={8}
+        top="1rem"
+        left="2.1875rem"
         zIndex={200}
         boxShadow="lg"
         display={{

--- a/src/pages/map/[view]/[geography].tsx
+++ b/src/pages/map/[view]/[geography].tsx
@@ -140,15 +140,11 @@ const MapPage = ({ initialRouteParams }: MapPageProps) => {
           {view === "datatool" && (
             <DataToolGeographySelect
               position="absolute"
-              top={5}
-              right={{
-                md: 8,
-                base: "auto",
+              top={{
+                base: "1rem",
+                md: "4.5rem",
               }}
-              left={{
-                md: "auto",
-                base: "2.1875rem",
-              }}
+              left="2.1875rem"
               zIndex={100}
               boxShadow="lg"
             />


### PR DESCRIPTION
Fixes [AB#6824](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/6824)

Stacks the Geo and View toggles at the top left of the map 
<img width="497" alt="image" src="https://user-images.githubusercontent.com/3311663/156636290-916db8df-e4fb-4b09-828e-c21209ef3bf7.png">
