### PR TITLE
7069 Select sub-categories within a Data Table category

### DIFF
--- a/src/constants/Subgroup.ts
+++ b/src/constants/Subgroup.ts
@@ -1,0 +1,7 @@
+export enum Subgroup {
+  TOT = "tot",
+  WNH = "wnh",
+  BNH = "bnh",
+  ANH = "anh",
+  HSP = "hsp",
+}

--- a/src/hooks/useDataExplorerState/useDataExplorerState.ts
+++ b/src/hooks/useDataExplorerState/useDataExplorerState.ts
@@ -1,22 +1,25 @@
 import { useRouter } from "next/router";
 import { Category } from "@constants/Category";
 import { Geography } from "@constants/geography";
+import { Subgroup } from "@constants/Subgroup";
 import { NYC } from "@constants/geoid";
 
 export interface DataExplorerState {
   geography: Geography;
   geoid: string;
   category: Category;
+  subgroup: string;
 }
 
 export const useDataExplorerState = (): DataExplorerState => {
   const router = useRouter();
-  const { geography, geoid, category } = router.query;
+  const { geography, geoid, category, subgroup } = router.query;
 
   const result: DataExplorerState = {
     geography: Geography.CITYWIDE,
     geoid: NYC,
     category: Category.DEMO,
+    subgroup: Subgroup.TOT,
   };
 
   if (
@@ -35,6 +38,13 @@ export const useDataExplorerState = (): DataExplorerState => {
     Object.values(Category).includes(category as Category)
   ) {
     result.category = category as Category;
+  }
+
+  if (
+    typeof subgroup === "string" &&
+    Object.values(Subgroup).includes(subgroup as Subgroup)
+  ) {
+    result.subgroup = subgroup as Subgroup;
   }
 
   return result;

--- a/src/pages/data/[geography]/[geoid]/[category].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category].tsx
@@ -23,6 +23,7 @@ import { CategoryMenu } from "@components/CategoryMenu";
 import { GeographyInfo } from "@components/GeographyInfo";
 import { useDataExplorerState } from "@hooks/useDataExplorerState";
 import { Geography } from "@constants/geography";
+import { useRouter } from "next/router";
 
 export interface DataPageProps {
   initialRouteParams: string;
@@ -223,7 +224,13 @@ const DataPage = ({ initialRouteParams }: DataPageProps) => {
   const [shouldShowReliability, setShouldShowReliability] =
     useState<boolean>(false);
 
-  const { subgroup } = useDataExplorerState();
+  const { geography, geoid, category, subgroup } = useDataExplorerState();
+  const router = useRouter();
+  const changeSubgroup = (event: any) => {
+    router.push(
+      `/data/${geography}/${geoid}/${category}?subgroup=${event.target.value}`
+    );
+  };
 
   return (
     <Flex
@@ -236,7 +243,7 @@ const DataPage = ({ initialRouteParams }: DataPageProps) => {
       <Box flexGrow={1} overflowX={"hidden"}>
         {/* <Box>Subgroup switcher can go here</Box> */}
         <Box>
-          <Select>
+          <Select onChange={changeSubgroup}>
             {subgroup === "tot" ? (
               <option value="tot" selected>
                 Total Population

--- a/src/pages/data/[geography]/[geoid]/[category].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category].tsx
@@ -243,42 +243,12 @@ const DataPage = ({ initialRouteParams }: DataPageProps) => {
       <Box flexGrow={1} overflowX={"hidden"}>
         {/* <Box>Subgroup switcher can go here</Box> */}
         <Box>
-          <Select onChange={changeSubgroup}>
-            {subgroup === "tot" ? (
-              <option value="tot" selected>
-                Total Population
-              </option>
-            ) : (
-              <option value="tot">Total Population</option>
-            )}
-            {subgroup === "wnh" ? (
-              <option value="wnh" selected>
-                White Non-hispanic
-              </option>
-            ) : (
-              <option value="wnh">White Non-hispanic</option>
-            )}
-            {subgroup === "bnh" ? (
-              <option value="bnh" selected>
-                Black Non-hispanic
-              </option>
-            ) : (
-              <option value="bnh">Black Non-hispanic</option>
-            )}
-            {subgroup === "anh" ? (
-              <option value="anh" selected>
-                Asian Non-hispanic
-              </option>
-            ) : (
-              <option value="anh">Asian Non-hispanic</option>
-            )}
-            {subgroup === "hsp" ? (
-              <option value="hsp" selected>
-                Hispanic
-              </option>
-            ) : (
-              <option value="hsp">Hispanic</option>
-            )}
+          <Select onChange={changeSubgroup} defaultValue={subgroup}>
+            <option value="tot">Total Population</option>
+            <option value="wnh">White Non-hispanic</option>
+            <option value="bnh">Black Non-hispanic</option>
+            <option value="anh">Asian Non-hispanic</option>
+            <option value="hsp">Hispanic</option>
           </Select>
         </Box>
         <Divider display={{ base: "none", md: "block" }} color={"gray.300"} />

--- a/src/pages/data/[geography]/[geoid]/[category].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category].tsx
@@ -14,6 +14,7 @@ import {
   FormControl,
   FormLabel,
   Switch,
+  Select,
 } from "@chakra-ui/react";
 import { ChevronLeftIcon, ChevronRightIcon } from "@chakra-ui/icons";
 import { EstimateTable } from "@components/EstimateTable";
@@ -222,6 +223,8 @@ const DataPage = ({ initialRouteParams }: DataPageProps) => {
   const [shouldShowReliability, setShouldShowReliability] =
     useState<boolean>(false);
 
+  const { subgroup } = useDataExplorerState();
+
   return (
     <Flex
       width={"full"}
@@ -231,7 +234,46 @@ const DataPage = ({ initialRouteParams }: DataPageProps) => {
     >
       <DataExplorerNav />
       <Box flexGrow={1} overflowX={"hidden"}>
-        <Box>Subgroup switcher can go here</Box>
+        {/* <Box>Subgroup switcher can go here</Box> */}
+        <Box>
+          <Select>
+            {subgroup === "tot" ? (
+              <option value="tot" selected>
+                Total Population
+              </option>
+            ) : (
+              <option value="tot">Total Population</option>
+            )}
+            {subgroup === "wnh" ? (
+              <option value="wnh" selected>
+                White Non-hispanic
+              </option>
+            ) : (
+              <option value="wnh">White Non-hispanic</option>
+            )}
+            {subgroup === "bnh" ? (
+              <option value="bnh" selected>
+                Black Non-hispanic
+              </option>
+            ) : (
+              <option value="bnh">Black Non-hispanic</option>
+            )}
+            {subgroup === "anh" ? (
+              <option value="anh" selected>
+                Asian Non-hispanic
+              </option>
+            ) : (
+              <option value="anh">Asian Non-hispanic</option>
+            )}
+            {subgroup === "hsp" ? (
+              <option value="hsp" selected>
+                Hispanic
+              </option>
+            ) : (
+              <option value="hsp">Hispanic</option>
+            )}
+          </Select>
+        </Box>
         <Divider display={{ base: "none", md: "block" }} color={"gray.300"} />
         <FormControl mb={4} display="flex" alignItems="center">
           <Switch

--- a/src/pages/data/[geography]/[geoid]/[category].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category].tsx
@@ -241,8 +241,7 @@ const DataPage = ({ initialRouteParams }: DataPageProps) => {
     >
       <DataExplorerNav />
       <Box flexGrow={1} overflowX={"hidden"}>
-        {/* <Box>Subgroup switcher can go here</Box> */}
-        <Box>
+        <Box width={{ base: "full", md: "max-content" }} p={"1rem"}>
           <Select onChange={changeSubgroup} defaultValue={subgroup}>
             <option value="tot">Total Population</option>
             <option value="wnh">White Non-hispanic</option>


### PR DESCRIPTION


### Summary
When I am viewing a data table (for example, the Demographic Conditions, HEC, etc), I want to be able to toggle between various subcategories (racial and ethnic groups) to display the relevant data 

## Acceptance Criteria
UI For switching categories will be dropdown box for all screen sizes (this is different from previous AC where UI was different on desktop)
    Dropdown width should be full width (with padding) on sizes smaller than "md". When larger than md, size can be determined naturally by items inside the dropdown. Note that dropdown appears below the category menu on mobile and at the top of the main content section on desktop, this should be natural with how the page is already laid out. [Figma](https://www.figma.com/file/U7dgahwMaggEmMI1l5O1Z9/Equitable-Development-Reporting---EDDT-Tool?node-id=2701:48489)
    When user selects a subcategory, it should be reflected via a query parameter added to the url. Ex: /data/district/4004/demo?subgroup=bnp. We can use these codes for the groups:
        tot - Total Population
        wnh - White Non-hispanic
        bnh - Black Non-hispanic
        anh - Asian Non-hispanic
        hsp - Hispanic
    Default group when a user switches categories should be Total Population

#### Tasks/Bug Numbers
 - Finishes user story AB#6670 and task AB#7069


