### PR TITLE
Task/7181 Prevent App Bar shrinking on About & Method pages

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -23,7 +23,6 @@ export const Header = () => {
   const isMobile = useWindowWidth() < 768;
   return (
     <Flex
-      flex="shrink"
       align="center"
       justify="space-between"
       as="header"

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Flex,
   Heading,
   IconButton,
@@ -10,6 +11,7 @@ import {
 } from "@chakra-ui/react";
 import { useWindowWidth } from "@react-hook/window-size";
 import Image from "next/image";
+import NextLink from "next/link";
 import { HamburgerIcon } from "@chakra-ui/icons";
 import { NavLink } from "@components/Header/NavLink";
 import * as React from "react";
@@ -88,17 +90,29 @@ export const Header = () => {
             </DrawerBody>
           </DrawerContent>
         </Drawer>
-        <Image src={logo} alt="City of New York Logo" height={22} width={66} />
-        <Heading
-          as="h1"
-          fontSize={{ base: "sm", md: "md" }}
-          color="gray.600"
-          fontWeight={{ base: "medium", md: "bold" }}
-          lineHeight="none"
-          marginLeft={{ base: 2, md: 4 }}
-        >
-          Equitable Development Data Tool
-        </Heading>
+        <NextLink href="/map/datatool/districts">
+          <Box cursor="pointer">
+            <Image
+              src={logo}
+              alt="City of New York Logo"
+              height={22}
+              width={66}
+            />
+          </Box>
+        </NextLink>
+        <NextLink href="/map/datatool/districts">
+          <Heading
+            as="h1"
+            fontSize={{ base: "sm", md: "md" }}
+            color="gray.600"
+            fontWeight={{ base: "medium", md: "bold" }}
+            lineHeight="none"
+            marginLeft={{ base: 2, md: 4 }}
+            cursor="pointer"
+          >
+            Equitable Development Data Tool
+          </Heading>
+        </NextLink>
       </Flex>
       <Flex
         direction="row"

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import { Flex } from "@chakra-ui/react";
+import { Box, Flex } from "@chakra-ui/react";
 import { Header } from "@components/Header";
 
 import { ChakraProvider } from "@chakra-ui/react";
@@ -14,9 +14,11 @@ function MyApp({ Component, pageProps }: AppProps) {
       <Flex height="100vh" direction="column">
         <Header />
 
-        <Flex direction="row" flex="auto">
-          <Component {...pageProps} />
-        </Flex>
+        <Box height="calc(100vh - 4.375rem)" overflow="auto">
+          <Flex direction="row" height="100%">
+            <Component {...pageProps} />
+          </Flex>
+        </Box>
       </Flex>
     </ChakraProvider>
   );


### PR DESCRIPTION
Fixes [AB#7181](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7181)

The problem was that when content overflowed the viewable screen, the Flex grid would kick in and try to minimize the App Bar height.

We change the container sibling to the App Bar to fill the rest remaining height of the screen, but scroll if its children exceed that height. 