### PR TITLE
Task/7314 GeographySelect remembers previously selected Geography & Geoid

### DIFF
--- a/cypress/integration/pages/Map/view/geography.spec.ts
+++ b/cypress/integration/pages/Map/view/geography.spec.ts
@@ -188,7 +188,7 @@ describe("Map catch-all page", () => {
       cy.get('[data-cy="desktopSidebar"]').should("not.be.visible");
 
       cy.get('[data-cy="openMobileDrawer"]').click();
-      cy.get('[data-cy="mobileDrawer"]').should("be.visible");
+      cy.get('[data-cy="mobileDrawer-welcome"]').should("be.visible");
     });
 
     it("should allow opening and closing Mobile Drawer", () => {
@@ -234,14 +234,14 @@ describe("Map catch-all page", () => {
     it("should display correct content in Drawer depending on view (Data Tool or DRI)", () => {
       cy.visit("/map/datatool/district");
 
-      cy.get('[data-cy="mobileDrawer"]').should(
+      cy.get('[data-cy="mobileDrawer-welcome"]').should(
         "contain",
         "Or switch to the Displacement Risk Index"
       );
 
       cy.get('[data-cy="driBtn-mobile"]').click();
 
-      cy.get('[data-cy="mobileDrawer"]').should(
+      cy.get('[data-cy="mobileDrawer-welcome"]').should(
         "contain",
         "Or switch to the Data Tool"
       );

--- a/cypress/integration/pages/Map/view/geography.spec.ts
+++ b/cypress/integration/pages/Map/view/geography.spec.ts
@@ -154,6 +154,28 @@ describe("Map catch-all page", () => {
         "Or switch to the Displacement Risk Index"
       );
     });
+
+    it("GeographySelect should remember previously selected District and Borough", () => {
+      cy.visit("/map/datatool/district?geoid=4108");
+
+      cy.get('[data-cy="boroughButton"]').click();
+
+      cy.url().should("not.include", "district?geoid=4108");
+
+      cy.get('[data-cy="districtButton"]').click();
+
+      cy.url().should("include", "district?geoid=4108");
+
+      cy.visit("/map/datatool/borough?geoid=BK0202");
+
+      cy.get('[data-cy="districtButton"]').click();
+
+      cy.url().should("not.include", "borough?geoid=BK0202");
+
+      cy.get('[data-cy="boroughButton"]').click();
+
+      cy.url().should("include", "borough?geoid=BK0202");
+    });
   });
 
   context("mobile", () => {
@@ -251,7 +273,7 @@ describe("Map catch-all page", () => {
       );
     });
 
-    it.only("should clear selection when user hits 'back' button", () => {
+    it("should clear selection when user hits 'back' button", () => {
       cy.visit("/map/datatool/district?geoid=4108");
 
       cy.get('[data-cy="mobileDrawer-datatool"]').should(

--- a/src/components/Map/DataTool/GeographySelect/GeographySelect.tsx
+++ b/src/components/Map/DataTool/GeographySelect/GeographySelect.tsx
@@ -1,19 +1,25 @@
-import { useRouter } from "next/router";
 import { BoxProps, Button } from "@chakra-ui/react";
 import { ToggleButtonGroup } from "@components/ToggleButtonGroup";
 import { useMapSubrouteInfo } from "@hooks/useMapSubrouteInfo";
 import { Geography } from "@constants/geography";
-import { NYC } from "@constants/geoid";
 
-export const GeographySelect = ({ ...boxProps }: BoxProps) => {
-  const router = useRouter();
+export interface GeographySelectInterface extends BoxProps {
+  onGeographySelect: (targetGeography: Geography) => void;
+}
+
+export const GeographySelect = ({
+  onGeographySelect,
+  ...boxProps
+}: GeographySelectInterface) => {
   const { geography } = useMapSubrouteInfo();
   const { DISTRICT, BOROUGH, CITYWIDE } = Geography;
 
   return (
     <ToggleButtonGroup isAttached={true} {...boxProps}>
       <Button
-        onClick={() => router.push(`/map/datatool/${DISTRICT}`)}
+        onClick={() => {
+          onGeographySelect(DISTRICT);
+        }}
         isActive={geography === DISTRICT}
         variant="leftCap"
         data-cy="districtButton"
@@ -21,7 +27,9 @@ export const GeographySelect = ({ ...boxProps }: BoxProps) => {
         Community District*
       </Button>
       <Button
-        onClick={() => router.push(`/map/datatool/${BOROUGH}`)}
+        onClick={() => {
+          onGeographySelect(BOROUGH);
+        }}
         isActive={geography === BOROUGH}
         variant="middle"
         data-cy="boroughButton"
@@ -29,7 +37,9 @@ export const GeographySelect = ({ ...boxProps }: BoxProps) => {
         Borough
       </Button>
       <Button
-        onClick={() => router.push(`/map/datatool/${CITYWIDE}?geoid=${NYC}`)}
+        onClick={() => {
+          onGeographySelect(CITYWIDE);
+        }}
         isActive={geography === CITYWIDE}
         variant="rightCap"
         data-cy="citywideButton"

--- a/src/pages/map/[view]/[geography].tsx
+++ b/src/pages/map/[view]/[geography].tsx
@@ -11,6 +11,7 @@ import { DRIMapLegend } from "@components/Map/DRI";
 import { SidebarContent } from "@components/SidebarContent";
 import { useMapSubrouteInfo } from "@hooks/useMapSubrouteInfo";
 import { Geography } from "@constants/geography";
+import { NYC } from "@constants/geoid";
 
 export interface MapPageProps {
   initialRouteParams: string;
@@ -51,7 +52,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 const MapPage = ({ initialRouteParams }: MapPageProps) => {
   console.log(initialRouteParams); // only here to prevent unused variable initialRouteParams?
 
-  const { DISTRICT, NTA } = Geography;
+  const { BOROUGH, CITYWIDE, DISTRICT, NTA } = Geography;
 
   const router = useRouter();
 
@@ -62,13 +63,18 @@ const MapPage = ({ initialRouteParams }: MapPageProps) => {
 
   const mapContainer = useRef<HTMLDivElement>(null);
 
-  const [lastDataToolGeography, setLastDataToolGeography] = useState(
-    (): string | null => null
-  );
-  const [lastDataToolGeoid, setLastDataToolGeoid] = useState(
-    (): string | null => null
+  const [lastDataToolGeography, setLastDataToolGeography] =
+    useState<Geography | null>(null);
+  const [lastDataToolGeoid, setLastDataToolGeoid] = useState<string | null>(
+    null
   );
   const [lastDriGeoid, setLastDriGeoid] = useState((): string | null => null);
+
+  const [lastDistrictGeoid, setLastDistrictGeoid] = useState<string | null>(
+    null
+  );
+
+  const [lastBoroughGeoid, setLastBoroughGeoid] = useState<string | null>(null);
 
   const onDriClick = () => {
     setLastDataToolGeography(geography);
@@ -101,6 +107,35 @@ const MapPage = ({ initialRouteParams }: MapPageProps) => {
     }
 
     router.push(dataToolPath);
+  };
+
+  const onDataToolGeographyChange = (targetGeography: Geography) => {
+    if (geography === targetGeography) return;
+
+    const targetUrl = `/map/datatool/${targetGeography}`;
+
+    if (geography === DISTRICT) setLastDistrictGeoid(geoid);
+    if (geography === BOROUGH) setLastBoroughGeoid(geoid);
+
+    if (targetGeography === CITYWIDE) {
+      router.push(`${targetUrl}?geoid=${NYC}`);
+
+      return;
+    }
+
+    if (targetGeography === DISTRICT && lastDistrictGeoid) {
+      router.push(`${targetUrl}?geoid=${lastDistrictGeoid}`);
+
+      return;
+    }
+
+    if (targetGeography === BOROUGH && lastBoroughGeoid) {
+      router.push(`${targetUrl}?geoid=${lastBoroughGeoid}`);
+
+      return;
+    }
+
+    router.push(`${targetUrl}`);
   };
 
   return (
@@ -150,6 +185,7 @@ const MapPage = ({ initialRouteParams }: MapPageProps) => {
               left="2.1875rem"
               zIndex={100}
               boxShadow="lg"
+              onGeographySelect={onDataToolGeographyChange}
             />
           )}
 


### PR DESCRIPTION
Fixes [AB#7314](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7314)

This PR ensures that toggling between geographies will preserve selected geographies. 
