### PR TITLE
7345 Export Data from Datatool Tables

### DIFF
--- a/src/components/DataDownloadModal/DataDownloadModal.tsx
+++ b/src/components/DataDownloadModal/DataDownloadModal.tsx
@@ -53,7 +53,7 @@ export const DataDownloadModal = ({
 
   return (
     <>
-      <Button variant="solid" colorScheme="teal" onClick={onOpen}>
+      <Button variant="download" colorScheme="teal" onClick={onOpen}>
         <Text display={{ base: "none", md: "inherit" }}>
           Download Data&nbsp;
         </Text>
@@ -117,7 +117,7 @@ export const DataDownloadModal = ({
                 p="1rem 0rem"
                 borderTopRadius={0}
                 onClick={submit}
-                variant="solid"
+                variant="download"
                 colorScheme="teal"
                 isDisabled={formSubmitDisabled}
               >

--- a/src/components/DataDownloadModal/DataDownloadModal.tsx
+++ b/src/components/DataDownloadModal/DataDownloadModal.tsx
@@ -18,6 +18,7 @@ import {
   ModalCloseButton,
 } from "@chakra-ui/react";
 import { FaDownload } from "react-icons/fa";
+import { usePumaInfo } from "@hooks/usePumaInfo";
 
 export interface DataDownloadModalProps {
   downloadType: string; // "datatool" | "dri";
@@ -42,6 +43,13 @@ export const DataDownloadModal = ({
       onClose();
     }
   };
+  const pumaInfo = usePumaInfo(geoid);
+  const geolabel = `PUMA ${pumaInfo?.id}: ${
+    pumaInfo?.neighborhoods
+  }, ${pumaInfo?.districts.slice(
+    8,
+    pumaInfo?.districts.indexOf(" CD")
+  )}, Citywide`;
 
   return (
     <>
@@ -72,7 +80,7 @@ export const DataDownloadModal = ({
             >
               GEOGRAPHY
             </Heading>
-            <Text pb="1rem">{geoid} and more stuff</Text>
+            <Text pb="1rem">{geolabel}</Text>
             <Heading
               fontSize="0.8125rem"
               color="#2C7A7B"

--- a/src/components/DataDownloadModal/DataDownloadModal.tsx
+++ b/src/components/DataDownloadModal/DataDownloadModal.tsx
@@ -1,0 +1,124 @@
+import { useState } from "react";
+import {
+  Heading,
+  FormControl,
+  Radio,
+  RadioGroup,
+  Stack,
+  Divider,
+  Text,
+  Button,
+  useDisclosure,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  ModalCloseButton,
+} from "@chakra-ui/react";
+import { FaDownload } from "react-icons/fa";
+
+export interface DataDownloadModalProps {
+  downloadType: string; // "datatool" | "dri";
+  geoid: string | null;
+}
+
+export const DataDownloadModal = ({
+  downloadType,
+  geoid,
+}: DataDownloadModalProps) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [formSubmitDisabled, setFormSubmitDisabled] = useState(true);
+  const [filetype, setFiletype] = useState("");
+  const updateFiletype = (ft: string) => {
+    console.log(downloadType, "to pass linting");
+    setFiletype(ft);
+    setFormSubmitDisabled(false);
+  };
+
+  const submit = () => {
+    if (!formSubmitDisabled) {
+      onClose();
+    }
+  };
+
+  return (
+    <>
+      <Button variant="solid" colorScheme="teal" onClick={onOpen}>
+        <Text display={{ base: "none", md: "inherit" }}>
+          Download Data&nbsp;
+        </Text>
+        <FaDownload />
+      </Button>
+
+      <Modal isOpen={isOpen} onClose={onClose} isCentered={true}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalCloseButton />
+          <ModalHeader p="1rem 1rem 1rem 1rem">
+            <Text fontWeight={700} fontSize="1.25rem">
+              Data Download Summary
+            </Text>
+          </ModalHeader>
+          <Divider color={"gray.200"} />
+
+          <ModalBody p="0rem 1rem">
+            <Heading
+              fontSize="0.8125rem"
+              color="#2C7A7B"
+              fontWeight={700}
+              pb="0.5rem"
+            >
+              GEOGRAPHY
+            </Heading>
+            <Text pb="1rem">{geoid} and more stuff</Text>
+            <Heading
+              fontSize="0.8125rem"
+              color="#2C7A7B"
+              fontWeight={700}
+              pb="0.5rem"
+            >
+              CATEGORIES
+            </Heading>
+            <Text pb="1rem">All</Text>
+            <Heading
+              fontSize="0.8125rem"
+              color="#2C7A7B"
+              fontWeight={700}
+              pb="0.5rem"
+            >
+              REPORT TYPE
+            </Heading>
+          </ModalBody>
+
+          <form>
+            <FormControl isRequired p="0rem 1rem 2.5rem">
+              <RadioGroup onChange={updateFiletype} value={filetype}>
+                <Stack direction="column">
+                  <Radio value="pdf">Community Profile (.pdf)</Radio>
+                  <Radio value="xls">Data set (.xls)</Radio>
+                </Stack>
+              </RadioGroup>
+            </FormControl>
+
+            <ModalFooter w="100%" p="0">
+              <Button
+                w="100%"
+                h="100%"
+                p="1rem 0rem"
+                borderTopRadius={0}
+                onClick={submit}
+                variant="solid"
+                colorScheme="teal"
+                isDisabled={formSubmitDisabled}
+              >
+                <FaDownload /> &nbsp;Download data
+              </Button>
+            </ModalFooter>
+          </form>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};

--- a/src/components/DataDownloadModal/DataDownloadModal.tsx
+++ b/src/components/DataDownloadModal/DataDownloadModal.tsx
@@ -21,7 +21,7 @@ import { FaDownload } from "react-icons/fa";
 import { usePumaInfo } from "@hooks/usePumaInfo";
 
 export interface DataDownloadModalProps {
-  downloadType: string; // "datatool" | "dri";
+  downloadType: "datatool" | "dri" | null;
   geoid: string | null;
 }
 
@@ -74,7 +74,7 @@ export const DataDownloadModal = ({
           <ModalBody p="0rem 1rem">
             <Heading
               fontSize="0.8125rem"
-              color="#2C7A7B"
+              color="teal.600"
               fontWeight={700}
               pb="0.5rem"
             >
@@ -83,7 +83,7 @@ export const DataDownloadModal = ({
             <Text pb="1rem">{geolabel}</Text>
             <Heading
               fontSize="0.8125rem"
-              color="#2C7A7B"
+              color="teal.600"
               fontWeight={700}
               pb="0.5rem"
             >
@@ -92,7 +92,7 @@ export const DataDownloadModal = ({
             <Text pb="1rem">All</Text>
             <Heading
               fontSize="0.8125rem"
-              color="#2C7A7B"
+              color="teal.600"
               fontWeight={700}
               pb="0.5rem"
             >

--- a/src/components/DataDownloadModal/index.ts
+++ b/src/components/DataDownloadModal/index.ts
@@ -1,0 +1,1 @@
+export * from "./DataDownloadModal";

--- a/src/components/SidebarContent/DRISelection/DRISelection.tsx
+++ b/src/components/SidebarContent/DRISelection/DRISelection.tsx
@@ -1,19 +1,15 @@
 import React from "react";
 import dridata from "@data/DRI_Subindices_Indicators.json";
-import { Box, Divider, Heading, Button, Text, Flex } from "@chakra-ui/react";
+import { Box, Divider, Heading, Text, Flex } from "@chakra-ui/react";
 import { useMapSubrouteInfo } from "@hooks/useMapSubrouteInfo";
 import { Subindicator } from "./Subindicator";
 import { DataPoint } from "./DataPoint";
-import { FaDownload } from "react-icons/fa";
+import { DataDownloadModal } from "@components/DataDownloadModal";
 
 export const DRISelection = () => {
   const { geoid } = useMapSubrouteInfo();
 
   const selectedDRIdata = dridata.find((nta: any) => nta.ntacode === geoid);
-
-  const downloadDRI = () => {
-    // At some point, we'll have to make this actually download something
-  };
 
   return (
     <>
@@ -25,9 +21,7 @@ export const DRISelection = () => {
             </Heading>
           </Box>
           <Box>
-            <Button variant="solid" colorScheme="teal" onClick={downloadDRI}>
-              <FaDownload />
-            </Button>
+            <DataDownloadModal downloadType="dri" geoid={geoid} />
           </Box>
         </Flex>
 

--- a/src/pages/data/[geography]/[geoid]/[category].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category].tsx
@@ -17,6 +17,7 @@ import {
   Select,
 } from "@chakra-ui/react";
 import { ChevronLeftIcon, ChevronRightIcon } from "@chakra-ui/icons";
+import { DataDownloadModal } from "@components/DataDownloadModal";
 import { EstimateTable } from "@components/EstimateTable";
 import { Estimate } from "@type/Estimate";
 import { CategoryMenu } from "@components/CategoryMenu";
@@ -241,6 +242,9 @@ const DataPage = ({ initialRouteParams }: DataPageProps) => {
     >
       <DataExplorerNav />
       <Box flexGrow={1} overflowX={"hidden"}>
+        <Box>
+          <DataDownloadModal downloadType="datatool" geoid={geoid} />
+        </Box>
         <Box width={{ base: "full", md: "max-content" }} p={"1rem"}>
           <Select onChange={changeSubgroup} defaultValue={subgroup}>
             <option value="tot">Total Population</option>

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -68,10 +68,15 @@ const theme = extendTheme({
         color: "gray.600",
 
         _hover: {
+          backgroundColor: "teal.50",
           color: "teal",
         },
         _active: {
           backgroundColor: "teal.50",
+          color: "teal",
+        },
+        _disabled: {
+          backgroundColor: "white",
           color: "teal",
         },
       },
@@ -91,6 +96,18 @@ const theme = extendTheme({
           borderRadius: 50,
           _active: {
             border: "1px solid teal",
+          },
+        },
+        download: {
+          backgroundColor: "teal",
+          color: "white",
+          _hover: {
+            backgroundColor: "teal.50",
+            color: "teal",
+          },
+          _disabled: {
+            backgroundColor: "white",
+            color: "teal",
           },
         },
       },


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
As a user viewing data in the Data Explorer
I would like to be able to download Excel and PDF version of that data
So that I can perform my own analysis outside of the EDDT 

<img width="475" alt="image" src="https://user-images.githubusercontent.com/61206501/158637664-968f7391-3207-4a98-a011-3f7a6cbc4ca1.png">


Acceptance Criteria:
    When a user exports data for a PUMA, they get all data for all categories for that PUMA, it's Borough, and Citywide
    A user can export Excel or PDF versions of the data
    Downloads match template that we will receive from SME's (waiting on finalized version)
    UI for downloading data conforms to designs in Figma (on both [web](https://www.figma.com/file/U7dgahwMaggEmMI1l5O1Z9/Equitable-Development-Reporting---EDDT-Tool?node-id=5351:149503) and [mobile](https://www.figma.com/file/U7dgahwMaggEmMI1l5O1Z9/Equitable-Development-Reporting---EDDT-Tool?node-id=5351:142269)

#### Tasks/Bug Numbers
 - Completes task [AB#7345](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7345) and user story [AB#6673](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/6673)

