### PR TITLE
7320 Fix DRISelection styles

### DIFF
--- a/src/components/SidebarContent/DRISelection/DataPoint.tsx
+++ b/src/components/SidebarContent/DRISelection/DataPoint.tsx
@@ -18,7 +18,7 @@ export const DataPoint = ({
 }: DataPointProps) => {
   return (
     <Box p="1.375rem 0.5rem 1.375rem 0.5rem">
-      <Heading fontSize="0.8125rem" color="#2C7A7B" fontWeight={400}>
+      <Heading fontSize="0.8125rem" color="teal.600" fontWeight={400}>
         {title.toUpperCase()}
       </Heading>
       <Flex direction="row" justifyContent="space-between">
@@ -29,7 +29,7 @@ export const DataPoint = ({
           </Text>
         </Box>
         <Box alignSelf="end">
-          <Text>{moe ? `${moe}% margin of error` : ""}</Text>
+          <Text color="gray.600">{moe ? `${moe}% margin of error` : ""}</Text>
         </Box>
       </Flex>
     </Box>

--- a/src/components/SidebarContent/DRISelection/Subindicator.tsx
+++ b/src/components/SidebarContent/DRISelection/Subindicator.tsx
@@ -8,7 +8,9 @@ interface SubindicatorProps {
 export const Subindicator = ({ subindicatorTitle }: SubindicatorProps) => {
   return (
     <Box p="1.5rem 0rem 0rem 0rem">
-      <Text fontSize="0.875rem">{subindicatorTitle}</Text>
+      <Text fontSize="0.875rem" fontWeight={500} color="gray.600">
+        {subindicatorTitle}
+      </Text>
     </Box>
   );
 };

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -1,8 +1,20 @@
 import { extendTheme } from "@chakra-ui/react";
 
-const fonts = { mono: `'Menlo', monospace` };
+const defaultFontFamily = "Helvetica Neue, Helvetica, sans-serif";
+
+const fonts = {
+  mono: `'Menlo', monospace`,
+  heading: defaultFontFamily,
+};
 
 const theme = extendTheme({
+  styles: {
+    global: {
+      "html, body": {
+        fontFamily: defaultFontFamily,
+      },
+    },
+  },
   colors: {
     black: "#16161D",
   },


### PR DESCRIPTION
When the DRISelection component was made it didn't align with spec styles. Also we never set a the global font family to Helvetica Neue

Fixes [AB#7320](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7320)