### PR TITLE
Configure GH Actions to restore e2e tests

### DIFF
--- a/.github/workflows/feature_branch.yml
+++ b/.github/workflows/feature_branch.yml
@@ -83,6 +83,15 @@ jobs:
     needs:
       - lint
     runs-on: ubuntu-latest
+    environment: development
+    env:
+      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
+      NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
+      NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
+      NEXT_PUBLIC_DO_SPACE_URL: ${{ secrets.DO_SPACE_URL }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup node env
@@ -101,16 +110,6 @@ jobs:
             ${{ runner.os }}-npm
       - name: Run e2e test
         run: npm run e2e:test
-        env:
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
-          NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
-          NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
-          NEXT_PUBLIC_DO_SPACE_URL: ${{ secrets.DO_SPACE_URL }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      - name: Run e2e test
-        run: npm run e2e:test
 
   deploy-preview:
     name: Preview Deploy
@@ -118,6 +117,14 @@ jobs:
       - lint
     runs-on: ubuntu-latest
     environment: development
+    env:
+      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
+      NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
+      NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
+      NEXT_PUBLIC_DO_SPACE_URL: ${{ secrets.DO_SPACE_URL }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup node env
@@ -138,11 +145,3 @@ jobs:
         run: |
           DEPLOY_ALIAS=${GITHUB_SHA:0:6}
           echo $(eval "netlify deploy --build --alias $DEPLOY_ALIAS")
-        env:
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
-          NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
-          NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
-          NEXT_PUBLIC_DO_SPACE_URL: ${{ secrets.DO_SPACE_URL }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/pr_merged.yml
+++ b/.github/workflows/pr_merged.yml
@@ -83,6 +83,15 @@ jobs:
     needs:
       - lint
     runs-on: ubuntu-latest
+    environment: staging
+    env:
+      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
+      NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
+      NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
+      NEXT_PUBLIC_DO_SPACE_URL: ${{ secrets.DO_SPACE_URL }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup node env
@@ -101,16 +110,6 @@ jobs:
             ${{ runner.os }}-npm
       - name: Run e2e test
         run: npm run e2e:test
-        env:
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
-          NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
-          NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
-          NEXT_PUBLIC_DO_SPACE_URL: ${{ secrets.DO_SPACE_URL }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      - name: Run e2e test
-        run: npm run e2e:test
 
   deploy-preview:
     name: Preview Deploy
@@ -118,6 +117,14 @@ jobs:
       - lint
     runs-on: ubuntu-latest
     environment: staging
+    env:
+      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
+      NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
+      NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
+      NEXT_PUBLIC_DO_SPACE_URL: ${{ secrets.DO_SPACE_URL }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup node env
@@ -136,11 +143,3 @@ jobs:
             ${{ runner.os }}-npm
       - name: Deploy Preview
         run: netlify deploy --build --alias staging
-        env:
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
-          NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
-          NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
-          NEXT_PUBLIC_DO_SPACE_URL: ${{ secrets.DO_SPACE_URL }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/release_and_deploy.yml
+++ b/.github/workflows/release_and_deploy.yml
@@ -84,7 +84,15 @@ jobs:
     needs:
       - lint
     runs-on: ubuntu-latest
-    environment: development
+    environment: production
+    env:
+      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
+      NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
+      NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
+      NEXT_PUBLIC_DO_SPACE_URL: ${{ secrets.DO_SPACE_URL }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -105,16 +113,6 @@ jobs:
             ${{ runner.os }}-node-
       - name: Run e2e test
         run: npm run e2e:test
-        env:
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
-          NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
-          NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
-          NEXT_PUBLIC_DO_SPACE_URL: ${{ secrets.DO_SPACE_URL }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      - name: Run e2e test
-        run: npm run e2e:test
 
   version-deploy:
     name: 🚀 Version and Deploy
@@ -122,6 +120,14 @@ jobs:
       - e2e
     runs-on: ubuntu-latest
     environment: production
+    env:
+        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+        NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
+        NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
+        NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
+        NEXT_PUBLIC_DO_SPACE_URL: ${{ secrets.DO_SPACE_URL }}
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -152,11 +158,3 @@ jobs:
           git push https://${{ secrets.SERVICE_ACCOUNT_NAME }}:${{ secrets.SERVICE_ACCOUNT_PAT }}@github.com/${{ github.repository }}.git HEAD:main --follow-tags
       - name: Deploy to Production
         run: netlify deploy --prod --build
-        env:
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
-          NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
-          NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
-          NEXT_PUBLIC_DO_SPACE_URL: ${{ secrets.DO_SPACE_URL }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/release_and_deploy.yml
+++ b/.github/workflows/release_and_deploy.yml
@@ -84,6 +84,7 @@ jobs:
     needs:
       - lint
     runs-on: ubuntu-latest
+    environment: development
     steps:
       - uses: actions/checkout@v2
         with:

--- a/cypress/integration/pages/data.geography.geoid.category/subgroup.spec.ts
+++ b/cypress/integration/pages/data.geography.geoid.category/subgroup.spec.ts
@@ -1,4 +1,4 @@
-describe("data/geography/geoid/category page", () => {
+describe("data/geography/geoid/category/subgroup page", () => {
   beforeEach(() => {
     cy.visit("data/borough/1/hopd/tot");
   });


### PR DESCRIPTION
**TL;DR:** 
Restore e2e test jobs in GitHub Actions. 

The issue was a duplicate test steps, and missing `environment` job property. 

----
After introducing Static Site Generation, the e2e tests for the data page started failing because the tests couldn't access the Digital Ocean space for static data to generate the data page. This was because the e2e test job wasn't correctly wired to the GitHub environment secrets. 

The e2e jobs across the 3 workflow files needed to be assigned to the respective environment (`development`, `staging`, production) to access the environment variables. 

There was also an accidental duplicate e2e test job in each workflow file.


