### PR TITLE
6875 Add functionatlity to Vintage components for handling multiple vintages

### DIFF
--- a/src/components/DataPointCell/DataPointCell.tsx
+++ b/src/components/DataPointCell/DataPointCell.tsx
@@ -6,9 +6,18 @@ export interface DataPointCellProps {
 }
 
 export const DataPointCell = ({ dataPoint }: DataPointCellProps) => {
-  let formattedValue = dataPoint.value.toLocaleString();
-  if (dataPoint.type === "PERCENT") {
-    formattedValue = `${formattedValue}%`;
+  const { value, measure } = dataPoint;
+  let formattedValue = "";
+  if (value === null) {
+    formattedValue = measure === "PERCENT" ? "0.0%" : "-";
+  } else {
+    formattedValue = value.toLocaleString(undefined, {
+      maximumFractionDigits: 1,
+      minimumFractionDigits: 0,
+    });
+    if (measure === "PERCENT") {
+      formattedValue = formattedValue + "%";
+    }
   }
   return (
     <Td

--- a/src/components/DataPointRow/DataPointRow.tsx
+++ b/src/components/DataPointRow/DataPointRow.tsx
@@ -1,0 +1,44 @@
+import { Tr, Td, TableRowProps } from "@chakra-ui/react";
+import { Row } from "@schemas/row";
+import { DataPointCell } from "@components/DataPointCell";
+
+export interface DataPointRowProps extends TableRowProps {
+  row: Row;
+}
+
+export const DataPointRow = ({ row, ...props }: DataPointRowProps) => {
+  const { label, isDenominator, cells } = row;
+  return (
+    <Tr
+      {...props}
+      _last={{
+        th: {
+          borderBottomLeftRadius: { base: "0.75rem", md: "0rem" },
+        },
+        "td:last-of-type": {
+          borderBottomRightRadius: {
+            base: "0.75rem",
+            md: "0rem",
+          },
+        },
+      }}
+    >
+      <Td
+        as="th"
+        scope="row"
+        fontWeight={isDenominator ? "700" : "400"}
+        zIndex={"100"}
+        minWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
+        maxWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
+        px={{ base: "0.375rem", md: "1.5rem" }}
+        position={"sticky"}
+        left={"0"}
+      >
+        {label}
+      </Td>
+      {cells.map((dataPoint, j) => (
+        <DataPointCell key={`data-point-cell-${j}`} dataPoint={dataPoint} />
+      ))}
+    </Tr>
+  );
+};

--- a/src/components/DataPointRow/index.ts
+++ b/src/components/DataPointRow/index.ts
@@ -1,0 +1,1 @@
+export * from "./DataPointRow";

--- a/src/components/Indicator/Indicator.tsx
+++ b/src/components/Indicator/Indicator.tsx
@@ -17,7 +17,7 @@ export const Indicator = ({ data }: IndicatorProps) => {
         marginBottom={{ base: "0.75rem", md: "1rem" }}
         textTransform={"capitalize"}
       >
-        {data.label}
+        {data.title}
       </Heading>
       <VintageList vintages={data.vintages} />
     </Box>

--- a/src/components/VintageList/VintageList.tsx
+++ b/src/components/VintageList/VintageList.tsx
@@ -1,4 +1,5 @@
-import { Box } from "@chakra-ui/react";
+import { useEffect, useState, useRef } from "react";
+import { Flex } from "@chakra-ui/react";
 import { Vintage } from "@schemas/vintage";
 import { VintageTable } from "@components/VintageTable";
 
@@ -7,15 +8,50 @@ export interface VintageListProps {
 }
 
 export const VintageList = ({ vintages }: VintageListProps) => {
+  const [rowHeights, setRowHeights] = useState<number[]>([]);
+
+  // This ref is passed to the first VintageTable for the indicator
+  // When multiple VintageTables are stacked horizontally on desktop, only the first
+  // renders the row labels. This ref is used
+  // to populate rowHeights so that row heights for all
+  // vintages have the same heights as the corresponding row in the first vintage
+  const ref = useRef<HTMLTableElement>(null);
+
+  useEffect(() => {
+    const heights: number[] = [];
+    ref.current?.querySelectorAll("tbody tr").forEach((node) => {
+      heights.push(node.clientHeight);
+    });
+    setRowHeights(heights);
+  }, []);
+
   return (
-    <Box
+    <Flex
       flexShrink={{ base: 1, md: 0 }}
-      overflowX={{ base: "auto", md: "hidden" }}
+      overflowX={{ base: "auto", md: "auto" }}
       paddingRight={{ base: "0rem", md: "1rem" }}
+      direction={{ base: "column", md: "row" }}
+      gridGap={{ base: "0.75rem", md: "0rem" }}
     >
-      {vintages.map((vintage, i) => (
-        <VintageTable key={`vintage-${i}`} vintage={vintage} />
-      ))}
-    </Box>
+      {vintages.map((vintage, i) => {
+        if (i === 0) {
+          return (
+            <VintageTable
+              ref={ref}
+              key={`vintage-${i}`}
+              vintage={vintage}
+              rowHeights={rowHeights}
+            />
+          );
+        }
+        return (
+          <VintageTable
+            key={`vintage-${i}`}
+            vintage={vintage}
+            rowHeights={rowHeights}
+          />
+        );
+      })}
+    </Flex>
   );
 };

--- a/src/components/VintageTable/VintageTable.tsx
+++ b/src/components/VintageTable/VintageTable.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react";
 import {
   Flex,
   Box,
@@ -7,161 +8,142 @@ import {
   Tbody,
   Th,
   Tr,
-  Td,
   useDisclosure,
 } from "@chakra-ui/react";
 import { ChevronDownIcon } from "@chakra-ui/icons";
-import { DataPointCell } from "@components/DataPointCell";
+import { DataPointRow } from "@components/DataPointRow";
 import { Vintage } from "@schemas/vintage";
 
 export interface VintageTableProps {
   vintage: Vintage;
+  rowHeights: number[];
 }
 
-export const VintageTable = ({ vintage }: VintageTableProps) => {
-  const { rows, headers, label } = vintage;
-  const { isOpen, onToggle } = useDisclosure({
-    defaultIsOpen: true,
-  });
-  return (
-    <Table
-      variant="striped"
-      sx={{
-        paddingRight: { base: 3, md: 0 },
-        display: "block",
-        overflowX: { base: "auto", md: "hidden" },
-        borderCollapse: "initial",
-        borderSpacing: 0,
-        fontSize: "0.875rem",
-        tableLayout: "fixed",
-      }}
-    >
-      <Thead>
-        <Tr>
-          <Th
-            rowSpan={headers.length + 1}
-            display={{ base: "none", md: "table-cell" }}
-            borderTopLeftRadius={{ base: "0.75rem", md: "0rem" }}
-            border={"none"}
-          ></Th>
-          <Th
-            onClick={onToggle}
-            colSpan={headers[0].length + 1}
-            borderTopLeftRadius={{ base: "0.75rem", md: "0rem" }}
-            borderTopRightRadius={"0.75rem"}
-            borderBottomLeftRadius={{
-              base: isOpen ? "0rem" : "0.75rem",
-              md: "0rem",
-            }}
-            borderBottomRightRadius={{
-              base: isOpen ? "0rem" : "0.75rem",
-              md: "0rem",
-            }}
-            px={"1rem"}
-            minWidth={{ base: "calc(100vw - 26px)", md: "auto" }}
-            maxWidth={{ base: "calc(100vw - 26px)", md: "auto" }}
-          >
-            <Flex
-              justifyContent={"center"}
-              align={"center"}
-              position={"relative"}
-            >
-              <Box px={{ base: "4.5rem", md: "0rem" }}>
-                <Text>{label}</Text>
-              </Box>
-              <Box
-                display={{ base: "block", md: "none" }}
-                position={"absolute"}
-                right={"0rem"}
-              >
-                <ChevronDownIcon
-                  transform={`rotate(${isOpen ? "0deg" : "-90deg"})`}
-                  color="teal.600"
-                  _hover={{ color: "teal.600" }}
-                  w={"2.5rem"}
-                  h={"2.5rem"}
-                />
-              </Box>
-            </Flex>
-          </Th>
-        </Tr>
-        {headers.map((headerRow, i, headers) => (
-          <Tr
-            display={{ base: isOpen ? "table-row" : "none", md: "table-row" }}
-            key={`header-row-${i}`}
-          >
-            {i === 0 && (
-              <Th
-                rowSpan={headers.length}
-                display={{ base: "table-cell", md: "none" }}
-                position={"sticky"}
-                left={"0"}
-                zIndex={"100"}
-                minWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
-                maxWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
-              >
-                data
-              </Th>
-            )}
-            {headerRow.map((headerCell, j) => (
-              <Th
-                colSpan={headerCell.colspan}
-                minWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
-                maxWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
-                key={`header-cell-${j}`}
-              >
-                {headerCell.label}
-              </Th>
-            ))}
-          </Tr>
-        ))}
-      </Thead>
-      <Tbody
-        display={{
-          base: isOpen ? "table-row-group" : "none",
-          md: "table-row-group",
+export const VintageTable = forwardRef<HTMLTableElement, VintageTableProps>(
+  ({ vintage, rowHeights }, ref) => {
+    const { rows, headers, label } = vintage;
+    const { isOpen, onToggle } = useDisclosure({
+      defaultIsOpen: true,
+    });
+
+    return (
+      <Table
+        variant="striped"
+        ref={ref}
+        sx={{
+          paddingRight: { base: 3, md: 0 },
+          display: "block",
+          overflowX: { base: "auto", md: "initial" },
+          borderCollapse: "initial",
+          borderSpacing: 0,
+          fontSize: "0.875rem",
+          tableLayout: "fixed",
+          width: "auto",
+          // These styles hide the row labels for all vintages after the first
+          // on desktop. Because vintages stack horizontally on desktop, we only need to
+          // render the labels once.
+          "&:not(:first-of-type)": {
+            "tbody tr th": {
+              display: { base: "table-cell", md: "none" },
+            },
+            "thead tr:first-of-type th:first-of-type": {
+              display: "none",
+            },
+          },
         }}
       >
-        {rows.map((row, i) => {
-          const { label, isDenominator, cells } = row;
-          return (
-            <Tr
-              key={`body-row-${i}`}
-              _last={{
-                th: {
-                  borderBottomLeftRadius: { base: "0.75rem", md: "0rem" },
-                },
-                "td:last-of-type": {
-                  borderBottomRightRadius: {
-                    base: "0.75rem",
-                    md: "0rem",
-                  },
-                },
+        <Thead>
+          <Tr>
+            <Th
+              rowSpan={headers.length + 1}
+              display={{ base: "none", md: "table-cell" }}
+              borderTopLeftRadius={"0.75rem"}
+              border={"none"}
+            ></Th>
+            <Th
+              onClick={onToggle}
+              colSpan={6}
+              borderTopLeftRadius={{ base: "0.75rem", md: "0rem" }}
+              borderTopRightRadius={{ base: "0.75rem", md: "0rem" }}
+              borderBottomLeftRadius={{
+                base: isOpen ? "0rem" : "0.75rem",
+                md: "0rem",
               }}
+              borderBottomRightRadius={{
+                base: isOpen ? "0rem" : "0.75rem",
+                md: "0rem",
+              }}
+              px={"1rem"}
+              minWidth={{ base: "calc(100vw - 26px)", md: "auto" }}
+              maxWidth={{ base: "calc(100vw - 26px)", md: "auto" }}
             >
-              <Td
-                as="th"
-                scope="row"
-                fontWeight={isDenominator ? "700" : "400"}
-                position={"sticky"}
-                left={"0"}
-                zIndex={"100"}
-                minWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
-                maxWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
-                px={{ base: "0.375rem", md: "1.5rem" }}
+              <Flex
+                justifyContent={"center"}
+                align={"center"}
+                position={"relative"}
               >
-                {label}
-              </Td>
-              {cells.map((dataPoint, j) => (
-                <DataPointCell
-                  key={`data-point-cell-${j}`}
-                  dataPoint={dataPoint}
-                />
+                <Box px={{ base: "4.5rem", md: "0rem" }}>
+                  <Text>{label}</Text>
+                </Box>
+                <Box
+                  display={{ base: "block", md: "none" }}
+                  position={"absolute"}
+                  right={"0rem"}
+                >
+                  <ChevronDownIcon
+                    transform={`rotate(${isOpen ? "0deg" : "-90deg"})`}
+                    color="teal.600"
+                    _hover={{ color: "teal.600" }}
+                    w={"2.5rem"}
+                    h={"2.5rem"}
+                  />
+                </Box>
+              </Flex>
+            </Th>
+          </Tr>
+          {headers.map((headerRow, i, headers) => (
+            <Tr
+              display={{ base: isOpen ? "table-row" : "none", md: "table-row" }}
+              key={`header-row-${i}`}
+            >
+              {i === 0 && (
+                <Th
+                  rowSpan={headers.length}
+                  display={{ base: "table-cell", md: "none" }}
+                  position={"sticky"}
+                  left={"0"}
+                  zIndex={"100"}
+                  minWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
+                  maxWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
+                >
+                  data
+                </Th>
+              )}
+
+              {headerRow.map((headerCell, j) => (
+                <Th
+                  colSpan={headerCell.colspan}
+                  minWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
+                  maxWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
+                  key={`header-cell-${j}`}
+                >
+                  {headerCell.label}
+                </Th>
               ))}
             </Tr>
-          );
-        })}
-      </Tbody>
-    </Table>
-  );
-};
+          ))}
+        </Thead>
+        <Tbody
+          display={{
+            base: isOpen ? "table-row-group" : "none",
+            md: "table-row-group",
+          }}
+        >
+          {rows.map((row, i) => (
+            <DataPointRow height={rowHeights[i]} key={i} row={row} />
+          ))}
+        </Tbody>
+      </Table>
+    );
+  }
+);

--- a/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
@@ -98,7 +98,11 @@ export const getStaticProps: GetStaticProps = async (context) => {
     const res = await dataExplorerService.get(geography, geoid, category);
     // Validate file follows expected schema
     const profile = await categoryProfileSchema.validate(res.data);
-    const hasRacialBreakdown = Object.keys(profile) === Object.values(Category);
+
+    // Enabled subgroup dropdown if category profile has values for each subgroup
+    const hasRacialBreakdown =
+      JSON.stringify(Object.keys(profile).sort()) ===
+      JSON.stringify(Object.values(Subgroup).sort());
     // Return Profile data for given subgroup
     if (hasOwnProperty(profile, subgroup)) {
       return {
@@ -112,8 +116,9 @@ export const getStaticProps: GetStaticProps = async (context) => {
     return {
       notFound: true,
     };
-  } catch {
+  } catch (e) {
     // TODO - Catch and handle errors here
+    console.log(e);
     // Return 404 if download or schema validation failed
     return {
       notFound: true,
@@ -243,12 +248,11 @@ const DataExplorerNav = () => {
 const DataPage = ({ hasRacialBreakdown, indicators }: DataPageProps) => {
   const [shouldShowReliability, setShouldShowReliability] =
     useState<boolean>(true);
-
   const { geography, geoid, category, subgroup } = useDataExplorerState();
   const router = useRouter();
   const changeSubgroup = (event: any) => {
     router.push(
-      `/data/${geography}/${geoid}/${category}?subgroup=${event.target.value}`
+      `/data/${geography}/${geoid}/${category}/${event.target.value}`
     );
   };
 

--- a/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
@@ -46,7 +46,7 @@ export const getStaticPaths: GetStaticPaths = () => {
   const boroCodes = ["1", "2", "3", "4", "5"];
   // subset of categories, add to this list when data
   // for a category is uploaded
-  const categories = [Category.HOPD];
+  const categories = [Category.HSAQ];
 
   categories.forEach((category) => {
     Object.values(Subgroup).forEach((subgroup) => {
@@ -113,6 +113,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
       notFound: true,
     };
   } catch {
+    // TODO - Catch and handle errors here
     // Return 404 if download or schema validation failed
     return {
       notFound: true,
@@ -241,7 +242,7 @@ const DataExplorerNav = () => {
 
 const DataPage = ({ hasRacialBreakdown, indicators }: DataPageProps) => {
   const [shouldShowReliability, setShouldShowReliability] =
-    useState<boolean>(false);
+    useState<boolean>(true);
 
   const { geography, geoid, category, subgroup } = useDataExplorerState();
   const router = useRouter();

--- a/src/schemas/dataPoint.ts
+++ b/src/schemas/dataPoint.ts
@@ -1,10 +1,11 @@
-import { object, string, boolean, number, InferType } from "yup";
+import { object, string, number, InferType } from "yup";
 
 export const dataPointSchema = object({
-  value: number().required(),
-  name: string().required(),
-  type: string().required(),
-  isReliable: boolean().optional(),
+  value: number().nullable().defined(),
+  measure: string()
+    .oneOf(["COUNT", "PERCENT", "RATE", "INDEX", "MEDIAN"])
+    .required(),
+  variance: string().oneOf(["NONE", "MOE", "CV"]).required(),
 });
 
 export type DataPoint = InferType<typeof dataPointSchema>;

--- a/src/schemas/indicatorRecord.ts
+++ b/src/schemas/indicatorRecord.ts
@@ -1,9 +1,9 @@
-import { object, string, array, InferType } from "yup";
+import { object, string, array, InferType, boolean } from "yup";
 import { vintageSchema } from "@schemas/vintage";
 
 export const indicatorRecordSchema = object({
-  extends: string().optional(),
-  label: string().required(),
+  title: string().required(),
+  isSurvey: boolean().required(),
   vintages: array().of(vintageSchema).required(),
 });
 


### PR DESCRIPTION
### Summary
This PR does three main things:

* Adds some functionality to the Indicator and Vintage components for handling the styling on desktop and mobile when there are multiple vintages under an indicator. 
* Updates the `getStaticPaths` in [subgroup].tsx to only attempt to pull Housing Security, Affordability, and Quality data - there is data in DO for 3 indicators in that category as of the writing of this PR. It should be the first category fully processed
* Updates the `dataPoint` schema to match some recent changes to our data pipeline and updates `DataPointCell.tsx` accordingly

One thing this PR _doesn't do_ that may seem to be missing: hooking up `shouldShowReliability` and adding logic to Vintage components for hiding those cells when it is set to true. In this PR, indicators with cv, moe, etc, will always show those cells. I'm going to cover that in another upcoming PR to keep the scope of this PR (somewhat) reasonable.

#### Tasks/Bug Numbers
 - Fixes [AB#6875](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/6875)

### Technical Explanation

#### Rendering multiple "Vintages"
When we have data for an indicator for more than one point in time, we render multiple "Vintages". On Mobile, those are stacked vertically:
![image](https://user-images.githubusercontent.com/9055367/160632601-f42a78eb-bc2c-483e-aff2-1a665aad11da.png)

And desktop those are "stacked" horizontally:
![image](https://user-images.githubusercontent.com/9055367/160632500-82d4d7b8-f15d-48c0-99f1-9d33e2960e59.png)

`VintageTable.tsx` is responsible for rendering the data cells for one Vintage (each screenshot above is showing 2 `VintageTables`). `VintageList` is responsible for rendering each Vintage in the indicator and handles [stacking them in the correct orientation based on screen width](https://github.com/NYCPlanning/equity-tool/compare/task/6875-explorer-desktop-styling?expand=1#diff-bc7d98451e76a80f04ef17ada7997884e73537ec741abc42c9cd1f1701145089R33). However, when they're stacked horizontally, we only need to show the "row labels" ("Total population", "Asian non-Hispanic", etc) once - for the first Vintage, so `VintageTable` has [some styling](https://github.com/NYCPlanning/equity-tool/compare/task/6875-explorer-desktop-styling?expand=1#diff-00f99adfa4a0384bb6065db6fd921960de2cc6205411eaa34e08289caf7eef88R45) to hide those cells on Vintages after the first. However, doing that causes the row heights to change when the row labels are long enough to take up more than one line, so rows don't line up properly:
![image](https://user-images.githubusercontent.com/9055367/160635424-f64c7e9a-9627-4e08-88fb-90c77dac1fbc.png)

To address this, I added [the ref and `rowHeights` in VintageList](https://github.com/NYCPlanning/equity-tool/compare/task/6875-explorer-desktop-styling?expand=1#diff-bc7d98451e76a80f04ef17ada7997884e73537ec741abc42c9cd1f1701145089R22) which passes a ref to the first vintage, stores each row's height, and sets those heights on the rows of the following vintages. I realize this solution feels a little heavy handed but it fixes the only thing stopping me from having to build completely separate desktop and mobile table components and I think this solution is preferable to that.

#### Updates to `dataPointSchema`
I updates `dataPointSchema` to have properties `measure` and `vintage`, with the list of possible values for each - this gives us a better way to encode "metadata" about the datapoint and matches with Data Engineering's terminology.

