### PR TITLE
Make e2e tests compatible with SSG

### DIFF
--- a/.github/workflows/feature_branch.yml
+++ b/.github/workflows/feature_branch.yml
@@ -90,7 +90,7 @@ jobs:
       NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
       NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
       NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
-      NEXT_PUBLIC_DO_SPACE_URL: ${{ secrets.DO_SPACE_URL }}
+      NEXT_PUBLIC_USE_FIXTURE: true
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pr_merged.yml
+++ b/.github/workflows/pr_merged.yml
@@ -90,7 +90,7 @@ jobs:
       NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
       NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
       NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
-      NEXT_PUBLIC_DO_SPACE_URL: ${{ secrets.DO_SPACE_URL }}
+      NEXT_PUBLIC_USE_FIXTURE: true
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release_and_deploy.yml
+++ b/.github/workflows/release_and_deploy.yml
@@ -91,7 +91,7 @@ jobs:
       NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
       NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
       NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
-      NEXT_PUBLIC_DO_SPACE_URL: ${{ secrets.DO_SPACE_URL }}
+      NEXT_PUBLIC_USE_FIXTURE: true
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v2

--- a/cypress/integration/pages/data.geography.geoid.category/subgroup.spec.ts
+++ b/cypress/integration/pages/data.geography.geoid.category/subgroup.spec.ts
@@ -1,6 +1,6 @@
 describe("data/geography/geoid/category/subgroup page", () => {
   beforeEach(() => {
-    cy.visit("data/borough/1/hopd/tot");
+    cy.visit("data/borough/1/hsaq/tot");
   });
 
   context("desktop", () => {
@@ -18,7 +18,7 @@ describe("data/geography/geoid/category/subgroup page", () => {
 
       cy.url().should("include", "/map/datatool/borough?geoid=1");
 
-      cy.visit("data/borough/1/hopd/tot");
+      cy.visit("data/borough/1/hsaq/tot");
 
       cy.get('[data-test="header-app-logo"]').click();
 

--- a/src/fixtures/borough_1_hsaq.js
+++ b/src/fixtures/borough_1_hsaq.js
@@ -1,0 +1,3013 @@
+export default {
+  tot: [
+    {
+      title: "Housing Tenure",
+      isSurvey: true,
+      vintages: [
+        {
+          label: "CENSUS PUMS, 2000",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+              {
+                label: "percent",
+                colspan: 2,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label: "Occupied housing units",
+              isDenominator: true,
+              cells: [
+                {
+                  value: 740737.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 5362.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 0.4,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 100.0,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: null,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Owner-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 149356.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 2971.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.2,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 20.2,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.4,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Renter-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 591381.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 2971.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 0.3,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 79.8,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.7,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          label: "ACS PUMS, 2008-2012",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+              {
+                label: "percent",
+                colspan: 2,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label: "Occupied housing units",
+              isDenominator: true,
+              cells: [
+                {
+                  value: 738133.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 3595.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 0.3,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 100.0,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: null,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Owner-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 164756.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 3186.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.2,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 22.3,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.4,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Renter-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 573377.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 4472.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 0.5,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 77.7,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.5,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          label: "ACS PUMS, 2015-2019",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+              {
+                label: "percent",
+                colspan: 2,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label: "Occupied housing units",
+              isDenominator: true,
+              cells: [
+                {
+                  value: 759461.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 4628.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 0.4,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 100.0,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: null,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Owner-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 181830.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 3851.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.3,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 23.9,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.5,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Renter-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 577631.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 4969.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 0.5,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 76.1,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.5,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      title: "Median Value (2019 dollars)",
+      isSurvey: true,
+      vintages: [
+        {
+          label: "ACS PUMS, 2008-2012",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label: "Owner-occupied units",
+              isDenominator: true,
+              cells: [
+                {
+                  value: 164756.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 3186.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.2,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+              ],
+            },
+            {
+              label: "Median value (dollars)",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 916520.0,
+                  measure: "MEDIAN",
+                  variance: "NONE",
+                },
+                {
+                  value: 24116.0,
+                  measure: "MEDIAN",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.6,
+                  measure: "MEDIAN",
+                  variance: "CV",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          label: "ACS PUMS, 2015-2019",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label: "Owner-occupied units",
+              isDenominator: true,
+              cells: [
+                {
+                  value: 181830.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 3851.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.3,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+              ],
+            },
+            {
+              label: "Median value (dollars)",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 987547.0,
+                  measure: "MEDIAN",
+                  variance: "NONE",
+                },
+                {
+                  value: 21119.0,
+                  measure: "MEDIAN",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.3,
+                  measure: "MEDIAN",
+                  variance: "CV",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      title:
+        "Rental Units Affordable To Households By Area Median Income (AMI) Band",
+      isSurvey: true,
+      vintages: [
+        {
+          label: "ACS PUMS, 2015-2019",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+              {
+                label: "percent",
+                colspan: 2,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label: "Extremely low-income (0-30% AMI)",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 83717.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 2899.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 2.1,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 14.8,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.5,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Very low-income (31-50% AMI)",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 73555.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 2916.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 2.4,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 13.0,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.5,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Low-income (51-80% AMI)",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 108506.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 3662.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 2.1,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 19.1,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.6,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Moderate-income (81-120% AMI)",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 114751.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 3222.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.7,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 20.2,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.5,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Middle-income (121-165% AMI)",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 103176.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 3674.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 2.2,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 18.2,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.6,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "High-income (166% or higher AMI)",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 82990.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 2835.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 2.1,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 14.6,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.5,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  anh: [
+    {
+      title: "Housing Tenure",
+      isSurvey: true,
+      vintages: [
+        {
+          label: "CENSUS PUMS, 2000",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+              {
+                label: "percent",
+                colspan: 2,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label:
+                "Occupied housing units with an Asian non-Hispanic householder",
+              isDenominator: true,
+              cells: [
+                {
+                  value: 59025.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 2005.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 2.1,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 100.0,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: null,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Owner-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 9242.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 822.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 5.4,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 15.7,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 1.3,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Renter-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 49783.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 1854.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 2.3,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 84.3,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 1.3,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          label: "ACS PUMS, 2008-2012",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+              {
+                label: "percent",
+                colspan: 2,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label:
+                "Occupied housing units with an Asian non-Hispanic householder",
+              isDenominator: true,
+              cells: [
+                {
+                  value: 78646.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 1999.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.5,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 100.0,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: null,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Owner-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 14746.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 1208.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 5.0,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 18.7,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 1.5,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Renter-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 63900.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 2018.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.9,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 81.3,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 1.5,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          label: "ACS PUMS, 2015-2019",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+              {
+                label: "percent",
+                colspan: 2,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label:
+                "Occupied housing units with an Asian non-Hispanic householder",
+              isDenominator: true,
+              cells: [
+                {
+                  value: 89120.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 2075.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.4,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 100.0,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: null,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Owner-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 20863.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 1390.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 4.1,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 23.4,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 1.5,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Renter-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 68257.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 1977.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.8,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 76.6,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 1.3,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      title: "Median Value (2019 dollars)",
+      isSurvey: true,
+      vintages: [
+        {
+          label: "ACS PUMS, 2008-2012",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label:
+                "Owner-occupied units with an Asian non-Hispanic householder",
+              isDenominator: true,
+              cells: [
+                {
+                  value: 14746.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 1208.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 5.0,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+              ],
+            },
+            {
+              label: "Median value (dollars)",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 802797.0,
+                  measure: "MEDIAN",
+                  variance: "NONE",
+                },
+                {
+                  value: 46420.0,
+                  measure: "MEDIAN",
+                  variance: "MOE",
+                },
+                {
+                  value: 3.5,
+                  measure: "MEDIAN",
+                  variance: "CV",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          label: "ACS PUMS, 2015-2019",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label:
+                "Owner-occupied units with an Asian non-Hispanic householder",
+              isDenominator: true,
+              cells: [
+                {
+                  value: 20863.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 1390.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 4.1,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+              ],
+            },
+            {
+              label: "Median value (dollars)",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 953604.0,
+                  measure: "MEDIAN",
+                  variance: "NONE",
+                },
+                {
+                  value: 44228.0,
+                  measure: "MEDIAN",
+                  variance: "MOE",
+                },
+                {
+                  value: 2.8,
+                  measure: "MEDIAN",
+                  variance: "CV",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      title:
+        "Rental Units Affordable To Households By Area Median Income (AMI) Band",
+      isSurvey: true,
+      vintages: [],
+    },
+  ],
+  bnh: [
+    {
+      title: "Housing Tenure",
+      isSurvey: true,
+      vintages: [
+        {
+          label: "CENSUS PUMS, 2000",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+              {
+                label: "percent",
+                colspan: 2,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label:
+                "Occupied housing units with a Black non-Hispanic householder",
+              isDenominator: true,
+              cells: [
+                {
+                  value: 103009.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 2562.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.5,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 100.0,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: null,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Owner-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 9279.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 824.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 5.4,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 9.0,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.8,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Renter-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 93730.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 2462.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.6,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 91.0,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.8,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          label: "ACS PUMS, 2008-2012",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+              {
+                label: "percent",
+                colspan: 2,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label:
+                "Occupied housing units with a Black non-Hispanic householder",
+              isDenominator: true,
+              cells: [
+                {
+                  value: 87702.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 1683.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.2,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 100.0,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: null,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Owner-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 9544.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 898.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 5.7,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 10.9,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 1.0,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Renter-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 78158.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 1913.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.5,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 89.1,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 1.4,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          label: "ACS PUMS, 2015-2019",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+              {
+                label: "percent",
+                colspan: 2,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label:
+                "Occupied housing units with a Black non-Hispanic householder",
+              isDenominator: true,
+              cells: [
+                {
+                  value: 85138.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 1908.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.4,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 100.0,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: null,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Owner-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 8996.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 1019.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 6.9,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 10.6,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 1.2,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Renter-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 76142.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 2006.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.6,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 89.4,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 1.2,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      title: "Median Value (2019 dollars)",
+      isSurvey: true,
+      vintages: [
+        {
+          label: "ACS PUMS, 2008-2012",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label:
+                "Owner-occupied units with a Black non-Hispanic householder",
+              isDenominator: true,
+              cells: [
+                {
+                  value: 9544.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 898.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 5.7,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+              ],
+            },
+            {
+              label: "Median value (dollars)",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 627240.0,
+                  measure: "MEDIAN",
+                  variance: "NONE",
+                },
+                {
+                  value: 109611.0,
+                  measure: "MEDIAN",
+                  variance: "MOE",
+                },
+                {
+                  value: 10.6,
+                  measure: "MEDIAN",
+                  variance: "CV",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          label: "ACS PUMS, 2015-2019",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label:
+                "Owner-occupied units with a Black non-Hispanic householder",
+              isDenominator: true,
+              cells: [
+                {
+                  value: 8996.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 1019.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 6.9,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+              ],
+            },
+            {
+              label: "Median value (dollars)",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 554175.0,
+                  measure: "MEDIAN",
+                  variance: "NONE",
+                },
+                {
+                  value: 67165.0,
+                  measure: "MEDIAN",
+                  variance: "MOE",
+                },
+                {
+                  value: 7.4,
+                  measure: "MEDIAN",
+                  variance: "CV",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      title:
+        "Rental Units Affordable To Households By Area Median Income (AMI) Band",
+      isSurvey: true,
+      vintages: [],
+    },
+  ],
+  wnh: [
+    {
+      title: "Housing Tenure",
+      isSurvey: true,
+      vintages: [
+        {
+          label: "CENSUS PUMS, 2000",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+              {
+                label: "percent",
+                colspan: 2,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label:
+                "Occupied housing units with a White non-Hispanic householder",
+              isDenominator: true,
+              cells: [
+                {
+                  value: 419951.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 3669.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 0.5,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 100.0,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: null,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Owner-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 120771.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 2736.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.4,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 28.8,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.6,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Renter-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 299180.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 3634.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 0.7,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 71.2,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.6,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          label: "ACS PUMS, 2008-2012",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+              {
+                label: "percent",
+                colspan: 2,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label:
+                "Occupied housing units with a White non-Hispanic householder",
+              isDenominator: true,
+              cells: [
+                {
+                  value: 414712.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 2604.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 0.4,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 100.0,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: null,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Owner-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 128053.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 2841.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.3,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 30.9,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.7,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Renter-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 286659.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 3425.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 0.7,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 69.1,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.7,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          label: "ACS PUMS, 2015-2019",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+              {
+                label: "percent",
+                colspan: 2,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label:
+                "Occupied housing units with a White non-Hispanic householder",
+              isDenominator: true,
+              cells: [
+                {
+                  value: 412657.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 2995.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 0.4,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 100.0,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: null,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Owner-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 135247.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 3298.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.5,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 32.8,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.8,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Renter-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 277410.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 3748.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 0.8,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 67.2,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.8,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      title: "Median Value (2019 dollars)",
+      isSurvey: true,
+      vintages: [
+        {
+          label: "ACS PUMS, 2008-2012",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label:
+                "Owner-occupied units with a White non-Hispanic householder",
+              isDenominator: true,
+              cells: [
+                {
+                  value: 128053.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 2841.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.3,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+              ],
+            },
+            {
+              label: "Median value (dollars)",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 980224.0,
+                  measure: "MEDIAN",
+                  variance: "NONE",
+                },
+                {
+                  value: 27236.0,
+                  measure: "MEDIAN",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.7,
+                  measure: "MEDIAN",
+                  variance: "CV",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          label: "ACS PUMS, 2015-2019",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label:
+                "Owner-occupied units with a White non-Hispanic householder",
+              isDenominator: true,
+              cells: [
+                {
+                  value: 135247.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 3298.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.5,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+              ],
+            },
+            {
+              label: "Median value (dollars)",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 1110512.0,
+                  measure: "MEDIAN",
+                  variance: "NONE",
+                },
+                {
+                  value: 45037.0,
+                  measure: "MEDIAN",
+                  variance: "MOE",
+                },
+                {
+                  value: 2.5,
+                  measure: "MEDIAN",
+                  variance: "CV",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      title:
+        "Rental Units Affordable To Households By Area Median Income (AMI) Band",
+      isSurvey: true,
+      vintages: [],
+    },
+  ],
+  hsp: [
+    {
+      title: "Housing Tenure",
+      isSurvey: true,
+      vintages: [
+        {
+          label: "CENSUS PUMS, 2000",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+              {
+                label: "percent",
+                colspan: 2,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label: "Occupied housing units with a Hispanic householder",
+              isDenominator: true,
+              cells: [
+                {
+                  value: 141089.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 2666.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.1,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 100.0,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: null,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Owner-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 8205.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 775.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 5.7,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 5.8,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.5,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Renter-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 132884.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 2841.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.3,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 94.2,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.9,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          label: "ACS PUMS, 2008-2012",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+              {
+                label: "percent",
+                colspan: 2,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label: "Occupied housing units with a Hispanic householder",
+              isDenominator: true,
+              cells: [
+                {
+                  value: 142659.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 2110.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 0.9,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 100.0,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: null,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Owner-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 10110.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 935.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 5.6,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 7.1,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.6,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Renter-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 132549.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 2034.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 0.9,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 92.9,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.4,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          label: "ACS PUMS, 2015-2019",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+              {
+                label: "percent",
+                colspan: 2,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label: "Occupied housing units with a Hispanic householder",
+              isDenominator: true,
+              cells: [
+                {
+                  value: 155122.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 2999.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.2,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 100.0,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: null,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Owner-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 13132.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 1459.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 6.8,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 8.5,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.9,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+            {
+              label: "Renter-occupied",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 141990.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 2773.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 1.2,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+                {
+                  value: 91.5,
+                  measure: "PERCENT",
+                  variance: "NONE",
+                },
+                {
+                  value: 0.3,
+                  measure: "PERCENT",
+                  variance: "MOE",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      title: "Median Value (2019 dollars)",
+      isSurvey: true,
+      vintages: [
+        {
+          label: "ACS PUMS, 2008-2012",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label: "Owner-occupied units with a Hispanic householder",
+              isDenominator: true,
+              cells: [
+                {
+                  value: 10110.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 935.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 5.6,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+              ],
+            },
+            {
+              label: "Median value (dollars)",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 702507.0,
+                  measure: "MEDIAN",
+                  variance: "NONE",
+                },
+                {
+                  value: 64055.0,
+                  measure: "MEDIAN",
+                  variance: "MOE",
+                },
+                {
+                  value: 5.5,
+                  measure: "MEDIAN",
+                  variance: "CV",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          label: "ACS PUMS, 2015-2019",
+          headers: [
+            [
+              {
+                label: "number",
+                colspan: 3,
+              },
+            ],
+            [
+              {
+                label: "estimate",
+                colspan: 1,
+              },
+              {
+                label: "moe",
+                colspan: 1,
+              },
+              {
+                label: "cv",
+                colspan: 1,
+              },
+            ],
+          ],
+          rows: [
+            {
+              label: "Owner-occupied units with a Hispanic householder",
+              isDenominator: true,
+              cells: [
+                {
+                  value: 13132.0,
+                  measure: "COUNT",
+                  variance: "NONE",
+                },
+                {
+                  value: 1459.0,
+                  measure: "COUNT",
+                  variance: "MOE",
+                },
+                {
+                  value: 6.8,
+                  measure: "COUNT",
+                  variance: "CV",
+                },
+              ],
+            },
+            {
+              label: "Median value (dollars)",
+              isDenominator: false,
+              cells: [
+                {
+                  value: 671598.0,
+                  measure: "MEDIAN",
+                  variance: "NONE",
+                },
+                {
+                  value: 55264.0,
+                  measure: "MEDIAN",
+                  variance: "MOE",
+                },
+                {
+                  value: 5.0,
+                  measure: "MEDIAN",
+                  variance: "CV",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      title:
+        "Rental Units Affordable To Households By Area Median Income (AMI) Band",
+      isSurvey: true,
+      vintages: [],
+    },
+  ],
+};

--- a/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
@@ -34,6 +34,7 @@ import { parseDataExplorerSelection } from "@helpers/parseDataExplorerSelection"
 import { Subgroup } from "@constants/Subgroup";
 import { hasOwnProperty } from "@helpers/hasOwnProperty";
 import { getBoroughName } from "@helpers/getBoroughName";
+import BOROUGH_1_HSAQ_TEST_JSON from "../../../../../fixtures/borough_1_hsaq";
 
 export interface DataPageProps {
   hasRacialBreakdown: boolean;
@@ -87,17 +88,25 @@ export const getStaticProps: GetStaticProps = async (context) => {
     context.params
   );
 
-  const dataExplorerService = new DataExplorerService(
-    process.env.NEXT_PUBLIC_DO_SPACE_URL
-      ? process.env.NEXT_PUBLIC_DO_SPACE_URL
-      : ""
-  );
-
   try {
-    // Download the data file for this geoid and category
-    const res = await dataExplorerService.get(geography, geoid, category);
-    // Validate file follows expected schema
-    const profile = await categoryProfileSchema.validate(res.data);
+    let dataExplorerService,
+      res,
+      profile = {};
+
+    if (process.env.NEXT_PUBLIC_USE_FIXTURE === "true") {
+      profile = await categoryProfileSchema.validate(BOROUGH_1_HSAQ_TEST_JSON);
+    } else {
+      dataExplorerService = new DataExplorerService(
+        process.env.NEXT_PUBLIC_DO_SPACE_URL
+          ? process.env.NEXT_PUBLIC_DO_SPACE_URL
+          : ""
+      );
+
+      // Download the data file for this geoid and category
+      res = await dataExplorerService.get(geography, geoid, category);
+      // Validate file follows expected schema
+      profile = await categoryProfileSchema.validate(res.data);
+    }
 
     // Enabled subgroup dropdown if category profile has values for each subgroup
     const hasRacialBreakdown =


### PR DESCRIPTION
I initially tried using `cy.intercept()`, but I think the problem with that is Static Site Generation runs `getStaticProps()` _before_ tests, so the requests to Digital Ocean for static files won't be intercepted. The workaround here is to set up a fixture folder within `src` and have in-app logic to toggle use of the fixtures, instead of inside the cypress framework.


One advantage of having the  `USE_FIXTURE` toggle in-app is that devs could potentially leverage it to continue loading the Data Page for UI development during data churn. Devs just need to watch out for schema changes. 