### PR TITLE
Task/7674 show hide reliability

### DIFF
--- a/src/components/DataPointCell/DataPointCell.tsx
+++ b/src/components/DataPointCell/DataPointCell.tsx
@@ -3,9 +3,13 @@ import { DataPoint } from "@schemas/dataPoint";
 
 export interface DataPointCellProps {
   dataPoint: DataPoint;
+  isReliable: boolean;
 }
 
-export const DataPointCell = ({ dataPoint }: DataPointCellProps) => {
+export const DataPointCell = ({
+  dataPoint,
+  isReliable,
+}: DataPointCellProps) => {
   const { value, measure } = dataPoint;
   let formattedValue = "";
   if (value === null) {
@@ -25,6 +29,7 @@ export const DataPointCell = ({ dataPoint }: DataPointCellProps) => {
       minWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
       maxWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
       px={"1.5rem"}
+      color={isReliable ? "gray.800" : "gray.400"}
     >
       {formattedValue}
     </Td>

--- a/src/components/DataPointRow/DataPointRow.tsx
+++ b/src/components/DataPointRow/DataPointRow.tsx
@@ -4,10 +4,17 @@ import { DataPointCell } from "@components/DataPointCell";
 
 export interface DataPointRowProps extends TableRowProps {
   row: Row;
+  shouldShowReliability: boolean;
 }
 
-export const DataPointRow = ({ row, ...props }: DataPointRowProps) => {
+export const DataPointRow = ({
+  row,
+  shouldShowReliability,
+  ...props
+}: DataPointRowProps) => {
   const { label, isDenominator, cells } = row;
+  const cv = cells.find((dataPoint) => dataPoint.variance === "CV");
+  const isReliable = cv && cv.value !== null && cv.value >= 20 ? false : true;
   return (
     <Tr
       {...props}
@@ -36,9 +43,22 @@ export const DataPointRow = ({ row, ...props }: DataPointRowProps) => {
       >
         {label}
       </Td>
-      {cells.map((dataPoint, j) => (
-        <DataPointCell key={`data-point-cell-${j}`} dataPoint={dataPoint} />
-      ))}
+      {cells
+        .filter((dataPoint) => {
+          // If showing reliability information, show all cells
+          if (shouldShowReliability) {
+            return true;
+          }
+          // Otherwise, only show those with variance of "NONE"
+          return dataPoint.variance === "NONE";
+        })
+        .map((dataPoint, j) => (
+          <DataPointCell
+            key={`data-point-cell-${j}`}
+            dataPoint={dataPoint}
+            isReliable={isReliable}
+          />
+        ))}
     </Tr>
   );
 };

--- a/src/components/Indicator/Indicator.tsx
+++ b/src/components/Indicator/Indicator.tsx
@@ -3,10 +3,14 @@ import { IndicatorRecord } from "@schemas/indicatorRecord";
 import { VintageList } from "@components/VintageList";
 
 export interface IndicatorProps {
-  data: IndicatorRecord;
+  indicator: IndicatorRecord;
+  shouldShowReliability: boolean;
 }
 
-export const Indicator = ({ data }: IndicatorProps) => {
+export const Indicator = ({
+  indicator,
+  shouldShowReliability,
+}: IndicatorProps) => {
   return (
     <Box marginBottom="1.5rem">
       <Heading
@@ -17,9 +21,13 @@ export const Indicator = ({ data }: IndicatorProps) => {
         marginBottom={{ base: "0.75rem", md: "1rem" }}
         textTransform={"capitalize"}
       >
-        {data.title}
+        {indicator.title}
       </Heading>
-      <VintageList vintages={data.vintages} />
+      <VintageList
+        vintages={indicator.vintages}
+        shouldShowReliability={shouldShowReliability}
+        isSurvey={indicator.isSurvey}
+      />
     </Box>
   );
 };

--- a/src/components/VintageList/VintageList.tsx
+++ b/src/components/VintageList/VintageList.tsx
@@ -5,9 +5,15 @@ import { VintageTable } from "@components/VintageTable";
 
 export interface VintageListProps {
   vintages: Vintage[];
+  shouldShowReliability: boolean;
+  isSurvey: boolean;
 }
 
-export const VintageList = ({ vintages }: VintageListProps) => {
+export const VintageList = ({
+  vintages,
+  shouldShowReliability,
+  isSurvey,
+}: VintageListProps) => {
   const [rowHeights, setRowHeights] = useState<number[]>([]);
 
   // This ref is passed to the first VintageTable for the indicator
@@ -41,6 +47,8 @@ export const VintageList = ({ vintages }: VintageListProps) => {
               key={`vintage-${i}`}
               vintage={vintage}
               rowHeights={rowHeights}
+              shouldShowReliability={shouldShowReliability}
+              isSurvey={isSurvey}
             />
           );
         }
@@ -49,6 +57,8 @@ export const VintageList = ({ vintages }: VintageListProps) => {
             key={`vintage-${i}`}
             vintage={vintage}
             rowHeights={rowHeights}
+            shouldShowReliability={shouldShowReliability}
+            isSurvey={isSurvey}
           />
         );
       })}

--- a/src/components/VintageTable/VintageTable.tsx
+++ b/src/components/VintageTable/VintageTable.tsx
@@ -17,10 +17,12 @@ import { Vintage } from "@schemas/vintage";
 export interface VintageTableProps {
   vintage: Vintage;
   rowHeights: number[];
+  shouldShowReliability: boolean;
+  isSurvey: boolean;
 }
 
 export const VintageTable = forwardRef<HTMLTableElement, VintageTableProps>(
-  ({ vintage, rowHeights }, ref) => {
+  ({ vintage, rowHeights, shouldShowReliability, isSurvey }, ref) => {
     const { rows, headers, label } = vintage;
     const { isOpen, onToggle } = useDisclosure({
       defaultIsOpen: true,
@@ -101,28 +103,27 @@ export const VintageTable = forwardRef<HTMLTableElement, VintageTableProps>(
               </Flex>
             </Th>
           </Tr>
-          {headers.map((headerRow, i, headers) => (
+          {/* If indicator data is a survey and shouldShowReliability is false,
+          just render first row of headers with colspan of 1 */}
+          {isSurvey && !shouldShowReliability ? (
             <Tr
               display={{ base: isOpen ? "table-row" : "none", md: "table-row" }}
-              key={`header-row-${i}`}
             >
-              {i === 0 && (
-                <Th
-                  rowSpan={headers.length}
-                  display={{ base: "table-cell", md: "none" }}
-                  position={"sticky"}
-                  left={"0"}
-                  zIndex={"100"}
-                  minWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
-                  maxWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
-                >
-                  data
-                </Th>
-              )}
+              <Th
+                rowSpan={headers.length}
+                display={{ base: "table-cell", md: "none" }}
+                position={"sticky"}
+                left={"0"}
+                zIndex={"100"}
+                minWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
+                maxWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
+              >
+                data
+              </Th>
 
-              {headerRow.map((headerCell, j) => (
+              {headers[0].map((headerCell, j) => (
                 <Th
-                  colSpan={headerCell.colspan}
+                  colSpan={1}
                   minWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
                   maxWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
                   key={`header-cell-${j}`}
@@ -131,7 +132,43 @@ export const VintageTable = forwardRef<HTMLTableElement, VintageTableProps>(
                 </Th>
               ))}
             </Tr>
-          ))}
+          ) : (
+            // Otherwise, render all header rows, taking colspans from the data
+            headers.map((headerRow, i, headers) => (
+              <Tr
+                display={{
+                  base: isOpen ? "table-row" : "none",
+                  md: "table-row",
+                }}
+                key={`header-row-${i}`}
+              >
+                {i === 0 && (
+                  <Th
+                    rowSpan={headers.length}
+                    display={{ base: "table-cell", md: "none" }}
+                    position={"sticky"}
+                    left={"0"}
+                    zIndex={"100"}
+                    minWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
+                    maxWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
+                  >
+                    data
+                  </Th>
+                )}
+
+                {headerRow.map((headerCell, j) => (
+                  <Th
+                    colSpan={headerCell.colspan}
+                    minWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
+                    maxWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
+                    key={`header-cell-${j}`}
+                  >
+                    {headerCell.label}
+                  </Th>
+                ))}
+              </Tr>
+            ))
+          )}
         </Thead>
         <Tbody
           display={{
@@ -140,7 +177,12 @@ export const VintageTable = forwardRef<HTMLTableElement, VintageTableProps>(
           }}
         >
           {rows.map((row, i) => (
-            <DataPointRow height={rowHeights[i]} key={i} row={row} />
+            <DataPointRow
+              shouldShowReliability={shouldShowReliability}
+              height={rowHeights[i]}
+              key={i}
+              row={row}
+            />
           ))}
         </Tbody>
       </Table>

--- a/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
@@ -78,7 +78,6 @@ export const getStaticPaths: GetStaticPaths = () => {
 };
 
 export const getStaticProps: GetStaticProps = async (context) => {
-  console.log("foo");
   if (typeof context.params === "undefined") {
     return {
       notFound: true,
@@ -247,6 +246,8 @@ const DataExplorerNav = () => {
 };
 
 const DataPage = ({ hasRacialBreakdown, indicators }: DataPageProps) => {
+  // TODO - Can refactor this flag into a Context so that it doesn't have to be
+  // prop drilled all the way down to VintageTable
   const [shouldShowReliability, setShouldShowReliability] =
     useState<boolean>(true);
   const { geography, geoid, category, subgroup } = useDataExplorerState();
@@ -306,7 +307,11 @@ const DataPage = ({ hasRacialBreakdown, indicators }: DataPageProps) => {
         </FormControl>
         <Box paddingLeft={{ base: "0.75rem", md: "1rem" }}>
           {indicators.map((indicator, i) => (
-            <Indicator key={`indicator-${i}`} data={indicator} />
+            <Indicator
+              key={`indicator-${i}`}
+              indicator={indicator}
+              shouldShowReliability={shouldShowReliability}
+            />
           ))}
         </Box>
       </Box>

--- a/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
@@ -78,6 +78,7 @@ export const getStaticPaths: GetStaticPaths = () => {
 };
 
 export const getStaticProps: GetStaticProps = async (context) => {
+  console.log("foo");
   if (typeof context.params === "undefined") {
     return {
       notFound: true,


### PR DESCRIPTION
### Summary
This PR adds two pieces of functionality related to "reliability" information:
* It adds the ability to show/hide reliability cells by toggling the `showShowReliability` flag.
* Graying numbers that are part of a vintage row that has a "CV" cell with a value of 20 or more.

#### Tasks/Bug Numbers
 - Fixes [AB#7674](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7674)

### Technical Explanation
Cells are hidden if the `dataPoint` they're associated with has a `variance` value that is anything other than `NONE`, this should catch all cv and moe dataPoints. This PR also adds some code to only render the first row of headers in each vintage if reliability is hidden and the indicator has an `isSurvey` property of `true`. 
