### PR TITLE
7736 DRM Sidebar Adjustment

### DIFF
--- a/src/components/SidebarContent/DRISelection/DRISelection.tsx
+++ b/src/components/SidebarContent/DRISelection/DRISelection.tsx
@@ -34,7 +34,6 @@ export const DRISelection = () => {
           subindicatorTitle="Vulnerability"
           subindicatorBin={selectedDRIdata?.populationvulnerability_reclass}
         />
-        <Text>{selectedDRIdata?.populationvulnerability_reclass}</Text>
         <DataPoint
           title="Non-white Population"
           value={selectedDRIdata?.percentnotwhite}


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
Removing the extra tag in the DRM sidebar "Vulnerability" subindicator. Please see below example with extra "Lower" tag.
![image](https://user-images.githubusercontent.com/61206501/160896977-3f21ddc3-e562-4fe3-bd4d-1219bfb174bb.png)


#### Tasks/Bug Numbers
 - Fixes [AB#7736](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7736)
### Technical Explanation
Removes line of code accidentally left in when first developing the feature.