### PR TITLE
7549 add CSS to control button size and background per figma designs

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -62,11 +62,11 @@ export const Header = () => {
               w={"100%"}
               h={"100%"}
               color={isOpen ? "teal.600" : "gray.600"}
+              maxWidth={6}
             />
           }
           display={{ base: "flex", md: "none" }}
           onClick={onToggle}
-          backgroundColor={"white"}
           minWidth={6}
           h={4}
           _hover={{
@@ -80,6 +80,11 @@ export const Header = () => {
           }}
           mr={6}
           transform={`scale(${isOpen ? "1.125, 1.0833" : "1, 1"})`}
+          bg="none"
+          borderRadius={0}
+          _active={{
+            bg: "none",
+          }}
         />
         <Drawer
           isOpen={isOpen && isMobile}


### PR DESCRIPTION

### Summary

   - The site navigation hamburger menu (HM) on mobile screens, specifically on Safari browsers was taking 50% of the header real estate. The HM was also rendering with grey and dark grey (when the menu was selected and active) contrary to designs.
   - I added CSS to to set a max-width on the HM and removed the background colors
   #### before fix
<img width="414" alt="hg-mobile-inactive" src="https://user-images.githubusercontent.com/11340947/160921131-de8b8e9f-8216-4990-a37f-992c87c9fe05.png">
<img width="446" alt="hg-mobile-active" src="https://user-images.githubusercontent.com/11340947/160921177-9f99fcf0-9ec8-4345-a31e-920365ba0d2c.png">

#### after fix
<img width="410" alt="hg-mobile-fixed" src="https://user-images.githubusercontent.com/11340947/160921255-a77534ea-f97a-4fea-9986-6ac7a3aa9379.png">



#### Tasks/Bug Numbers
 - Fixes [AB#7549](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7549)

[AB7549](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/7549)

