### PR TITLE
6875 Adds support for placeholder field on rows

### DIFF
--- a/src/components/DataPointRow/DataPointRow.tsx
+++ b/src/components/DataPointRow/DataPointRow.tsx
@@ -12,7 +12,49 @@ export const DataPointRow = ({
   shouldShowReliability,
   ...props
 }: DataPointRowProps) => {
-  const { label, isDenominator, cells } = row;
+  const { label, isDenominator, cells, placeholder = "" } = row;
+
+  if (cells === null) {
+    return (
+      <Tr
+        {...props}
+        _last={{
+          th: {
+            borderBottomLeftRadius: { base: "0.75rem", md: "0rem" },
+          },
+          "td:last-of-type": {
+            borderBottomRightRadius: {
+              base: "0.75rem",
+              md: "0rem",
+            },
+          },
+        }}
+      >
+        <Td
+          as="th"
+          scope="row"
+          fontWeight={isDenominator ? "700" : "400"}
+          zIndex={"100"}
+          minWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
+          maxWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
+          px={{ base: "0.375rem", md: "1.5rem" }}
+          position={"sticky"}
+          left={"0"}
+        >
+          {label}
+        </Td>
+        <Td
+          minWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
+          maxWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
+          px={"1.5rem"}
+          colSpan={5}
+        >
+          {placeholder}
+        </Td>
+      </Tr>
+    );
+  }
+
   const cv = cells.find((dataPoint) => dataPoint.variance === "CV");
   const isReliable = cv && cv.value !== null && cv.value >= 20 ? false : true;
   return (

--- a/src/schemas/row.ts
+++ b/src/schemas/row.ts
@@ -3,8 +3,9 @@ import { dataPointSchema } from "@schemas/dataPoint";
 
 export const rowSchema = object({
   label: string().required(),
-  cells: array().of(dataPointSchema).required(),
+  cells: array().of(dataPointSchema).nullable().defined(),
   isDenominator: boolean().optional(),
+  placeholder: string().optional(),
 });
 
 export type Row = InferType<typeof rowSchema>;

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -38,7 +38,6 @@ const theme = extendTheme({
           td: {
             borderWidth: "1px",
             borderColor: "gray.300",
-            textTransform: "capitalize",
             textAlign: "left",
             py: "0.75rem",
           },


### PR DESCRIPTION
### Summary
This PR adds support for `rowSchema` instances with a "placeholder" field, this is the field we use to indicate that data isn't available for a given indicator at the given geography or subgroup

#### Tasks/Bug Numbers
 - Fixes [AB#6875](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/6875)

### Technical Explanation
Just adds a field to the schema and makes `cells` nullable, and updates `DataPointRow.tsx` to handle the change - the data files will always have `cells`, but it will be null for placeholder rows. Also has a small change in `theme` to fix a bug where strings were getting incorrectly capitalized.
