### PR TITLE
7779 Font Spacing

### DIFF
--- a/src/components/SidebarContent/SidebarContent.tsx
+++ b/src/components/SidebarContent/SidebarContent.tsx
@@ -36,7 +36,7 @@ export const SidebarContent = () => {
           </Button>
         </Box>
         <Flex direction="row" justifyContent="space-between">
-          <Box padding="0 1rem 1.5rem 1rem">
+          <Box padding="1rem 1rem 1.5rem 1rem">
             <GeographyInfo
               geoid={geoid}
               geography={geography}


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
"There should be additional 12 px padding above the PUMA label and below the back button"
I did 16px, which I think is the correct amount

#### Tasks/Bug Numbers
 - Fixes [AB#7779](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7779)

Preview: https://42802a--equity-tool.netlify.app/map/datatool/district?geoid=3803