### PR TITLE
7775 Opaque DRM Drawer nav bar

### DIFF
--- a/src/components/Map/DRI/MobileDrawer.tsx
+++ b/src/components/Map/DRI/MobileDrawer.tsx
@@ -46,7 +46,7 @@ export const DriMobileDrawer = () => {
           zIndex="999"
           justifyContent="space-between"
           flexDirection="row"
-          bg="rgba(0,0,0,0)"
+          bg="white"
         >
           <Button
             padding="1.5rem 1rem"


### PR DESCRIPTION
Fixes [AB#7775](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7775) 
Makes the top navbar in the DRM Drawer  opaque
![image](https://user-images.githubusercontent.com/3311663/161749244-b964216e-6691-472b-83f8-68cb7280f5e3.png)
