### PR TITLE
7829 Enable Econ data page

### DIFF
--- a/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
@@ -46,7 +46,7 @@ export const getStaticPaths: GetStaticPaths = () => {
   const boroCodes = ["1", "2", "3", "4", "5"];
   // subset of categories, add to this list when data
   // for a category is uploaded
-  const categories = [Category.HSAQ];
+  const categories = [Category.HSAQ, Category.ECON];
 
   categories.forEach((category) => {
     Object.values(Subgroup).forEach((subgroup) => {

--- a/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
@@ -46,7 +46,13 @@ export const getStaticPaths: GetStaticPaths = () => {
   const boroCodes = ["1", "2", "3", "4", "5"];
   // subset of categories, add to this list when data
   // for a category is uploaded
-  const categories = [Category.HSAQ, Category.ECON];
+  const categories = [
+    Category.DEMO,
+    Category.ECON,
+    Category.HSAQ,
+    Category.HOPD,
+    Category.QLAO,
+  ];
 
   categories.forEach((category) => {
     Object.values(Subgroup).forEach((subgroup) => {


### PR DESCRIPTION
Fixes [AB#7829](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7829) 
This is necessary in order to load the Econ data page.  Econ data is already on Digital Ocean. 