### PR TITLE
7776 removed  Data Tool link  from WelcomeContent per figma

### DIFF
--- a/src/components/WelcomeContent.tsx
+++ b/src/components/WelcomeContent.tsx
@@ -30,21 +30,6 @@ const WelcomeContent = () => {
           see the level of risk residents face of being unable to remain in
           their homes or neighborhoods.
         </Text>
-
-        <br />
-
-        <Link
-          href="/about"
-          onClick={() => {
-            ReactGA.event({
-              category: "Learn More About the Data Tool",
-              action: "Click",
-              label: "Learn More About the Data Tool",
-            });
-          }}
-        >
-          Learn More About the Data Tool
-        </Link>
       </>
     );
   }


### PR DESCRIPTION
### Summary
Removed `Learn More About the Data Tool` from the WelcomeContent page 

#### Tasks Number
 - Fixes [AB#7776](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7776)
[AB7776](https://dev.azure.com/NYCPlanning/ITD/_sprints/taskboard/Open%20Source%20Engineering/ITD/2022/Q2/Sprint%20H?workitem=7776)


#### Related to Previous Commit
[7776 updated welcome/community data page text](https://github.com/NYCPlanning/equity-tool/commit/c8f93184677361c45ab3e1c96d60467d260abdfd)