### PR TITLE
Fix rounding logic in DataPointCell

### DIFF
--- a/src/components/DataPointCell/DataPointCell.tsx
+++ b/src/components/DataPointCell/DataPointCell.tsx
@@ -10,14 +10,15 @@ export const DataPointCell = ({
   dataPoint,
   isReliable,
 }: DataPointCellProps) => {
-  const { value, measure } = dataPoint;
+  const { value, measure, variance } = dataPoint;
+  const roundTo = measure === "PERCENT" || variance === "CV" ? 1 : 0;
   let formattedValue = "";
   if (value === null) {
-    formattedValue = measure === "PERCENT" ? "0.0%" : "-";
+    formattedValue = "-";
   } else {
     formattedValue = value.toLocaleString(undefined, {
-      maximumFractionDigits: 1,
-      minimumFractionDigits: 0,
+      maximumFractionDigits: roundTo,
+      minimumFractionDigits: roundTo,
     });
     if (measure === "PERCENT") {
       formattedValue = formattedValue + "%";


### PR DESCRIPTION
### Summary
This PR implements logic to show the correct number of digits past the decimal point in the Data Table Cells. 

#### Tasks/Bug Numbers
 - Fixes [AB#7849](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7849)
 - Fixes [AB#7891](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7891)

### Technical Explanation
The requirements that this implements are that datapoints where the `variance` is CV and datapoints where the measure is `percent` should have 1 digit past the decimal point (even if it's just `.0`) while all others should have 0
