### PR TITLE
Fix subgroup dropdown to reflect correct value

### DIFF
--- a/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
@@ -216,7 +216,7 @@ const DataPage = ({
             <Select
               isDisabled={!hasRacialBreakdown}
               onChange={changeSubgroup}
-              defaultValue={subgroup}
+              value={subgroup}
             >
               <option value="tot">Total Population</option>
               <option value="anh">Asian Non-hispanic</option>


### PR DESCRIPTION
### Summary
This PR fixes a bug where the dropdown for subgroup wasn't being kept up to date with the route state because it was using `defaultValue` instead of `value`

#### Tasks/Bug Numbers
 - Fixes [AB#7916](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7916)
