### PR TITLE
7803 Add to useEffect dep array so that row heights are kept in sync

### DIFF
--- a/src/components/VintageList/VintageList.tsx
+++ b/src/components/VintageList/VintageList.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useRef } from "react";
 import { Flex } from "@chakra-ui/react";
 import { Vintage } from "@schemas/vintage";
 import { VintageTable } from "@components/VintageTable";
+import { useDataExplorerState } from "@hooks/useDataExplorerState";
 
 export interface VintageListProps {
   vintages: Vintage[];
@@ -22,14 +23,16 @@ export const VintageList = ({
   // to populate rowHeights so that row heights for all
   // vintages have the same heights as the corresponding row in the first vintage
   const ref = useRef<HTMLTableElement>(null);
+  const { category, subgroup } = useDataExplorerState();
 
+  // Update row heights whenever category or subgroup changes
   useEffect(() => {
     const heights: number[] = [];
     ref.current?.querySelectorAll("tbody tr").forEach((node) => {
       heights.push(node.clientHeight);
     });
     setRowHeights(heights);
-  }, []);
+  }, [category, subgroup]);
 
   return (
     <Flex


### PR DESCRIPTION
### Summary
This PR fixes a bug where the data row heights weren't lining up across vintages after switching between categories or subgroups

#### Tasks/Bug Numbers
 - Fixes [AB#7803](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7803)

### Technical Explanation
We use a `ref` and the `rowHeights` state variable to keep these row heights aligned when the vintages are stacked horizontally on desktop. The useEffect for that wasn't updating properly so I added category and subgroup to it's dependency array.
