### PR TITLE
7345 Add back download link

### DIFF
--- a/src/components/DataDownloadModal/DataDownloadModal.tsx
+++ b/src/components/DataDownloadModal/DataDownloadModal.tsx
@@ -20,24 +20,53 @@ import {
 } from "@chakra-ui/react";
 import { FaDownload } from "react-icons/fa";
 import { usePumaInfo } from "@hooks/usePumaInfo";
+import { Geography } from "@constants/geography";
+import { getBoroughAbbreviation } from "@helpers/getBoroughAbbreviation";
 import ReactGA from "react-ga4";
 
 export interface DataDownloadModalProps {
   downloadType: "data" | "drm" | null;
   geoid: string | null;
+  geography: Geography | null;
 }
 
 export const DataDownloadModal = ({
   downloadType,
   geoid,
+  geography,
 }: DataDownloadModalProps) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [formSubmitDisabled, setFormSubmitDisabled] = useState(true);
   const [filetype, setFiletype] = useState("");
   const updateFiletype = (ft: string) => {
-    console.log(downloadType, "to pass linting");
     setFiletype(ft);
     setFormSubmitDisabled(false);
+  };
+
+  const baseUrl = "https://equity-tool-data.nyc3.digitaloceanspaces.com";
+
+  const getUrl = () => {
+    if (downloadType === "drm") {
+      return `${baseUrl}/DRI_Subindices_Indicators.xls`;
+    }
+
+    if (geoid === null) {
+      return "#";
+    }
+
+    const typeString = filetype === "xls" ? "xlsx" : "pdf";
+
+    if (geography === Geography.CITYWIDE) {
+      return `${baseUrl}/downloads/citywide_${typeString}.zip`;
+    }
+
+    if (geography === Geography.BOROUGH) {
+      return `${baseUrl}/downloads/${getBoroughAbbreviation(
+        geoid
+      )}_${typeString}.zip`;
+    }
+
+    return `${baseUrl}/downloads/${geoid}_${typeString}.zip`;
   };
 
   const submit = () => {
@@ -141,11 +170,7 @@ export const DataDownloadModal = ({
               <Text pb="1rem">Data set (.xls)</Text>
             </ModalBody>
             <ModalFooter w="100%" p="0">
-              <Link
-                href="https://equity-tool-data.nyc3.digitaloceanspaces.com/DRI_Subindices_Indicators.xls"
-                isExternal={true}
-                w="100%"
-              >
+              <Link href={getUrl()} isExternal={true} w="100%">
                 <Button
                   w="100%"
                   h="100%"
@@ -180,7 +205,7 @@ export const DataDownloadModal = ({
           <ModalCloseButton />
           <ModalHeader p="1rem 1rem 1rem 1rem">
             <Text fontWeight={700} fontSize="1.25rem">
-              Data Download Summary
+              Data Download
             </Text>
           </ModalHeader>
           <Divider color={"gray.200"} />
@@ -191,6 +216,7 @@ export const DataDownloadModal = ({
               color="teal.600"
               fontWeight={700}
               pb="0.5rem"
+              pt="1rem"
             >
               GEOGRAPHY
             </Heading>
@@ -218,25 +244,29 @@ export const DataDownloadModal = ({
             <FormControl isRequired p="0rem 1rem 2.5rem">
               <RadioGroup onChange={updateFiletype} value={filetype}>
                 <Stack direction="column">
-                  <Radio value="pdf">Community Profile (.pdf)</Radio>
+                  <Radio isDisabled={true} value="pdf">
+                    Community Profile (.pdf) (coming soon)
+                  </Radio>
                   <Radio value="xls">Data set (.xls)</Radio>
                 </Stack>
               </RadioGroup>
             </FormControl>
 
             <ModalFooter w="100%" p="0">
-              <Button
-                w="100%"
-                h="100%"
-                p="1rem 0rem"
-                borderTopRadius={0}
-                onClick={submit}
-                variant="download"
-                colorScheme="teal"
-                isDisabled={formSubmitDisabled}
-              >
-                <FaDownload /> &nbsp;Download data
-              </Button>
+              <Link href={getUrl()} isExternal={true} w="100%">
+                <Button
+                  w="100%"
+                  h="100%"
+                  p="1rem 0rem"
+                  borderTopRadius={0}
+                  onClick={submit}
+                  variant="download"
+                  colorScheme="teal"
+                  isDisabled={formSubmitDisabled}
+                >
+                  <FaDownload /> &nbsp;Download data
+                </Button>
+              </Link>
             </ModalFooter>
           </form>
         </ModalContent>

--- a/src/components/Map/DRM/MobileDrawer.tsx
+++ b/src/components/Map/DRM/MobileDrawer.tsx
@@ -76,7 +76,11 @@ export const DrmMobileDrawer = () => {
           >
             {isOpen ? (
               <>
-                <DataDownloadModal downloadType="drm" geoid={geoid} />
+                <DataDownloadModal
+                  downloadType="drm"
+                  geoid={geoid}
+                  geography={geography}
+                />
                 <IconButton
                   variant="ghost"
                   size="lg"

--- a/src/components/SidebarContent/SidebarContent.tsx
+++ b/src/components/SidebarContent/SidebarContent.tsx
@@ -39,7 +39,11 @@ export const SidebarContent = () => {
           </Box>
           <Box pr="1rem">
             {view === "drm" && (
-              <DataDownloadModal downloadType="drm" geoid={geoid} />
+              <DataDownloadModal
+                downloadType="drm"
+                geoid={geoid}
+                geography={geography}
+              />
             )}
           </Box>
         </Flex>

--- a/src/helpers/getBoroughAbbreviation.ts
+++ b/src/helpers/getBoroughAbbreviation.ts
@@ -1,0 +1,13 @@
+import { hasOwnProperty } from "@helpers/hasOwnProperty";
+
+export const getBoroughAbbreviation = (id: string) => {
+  const boroughs = {
+    "1": "MN",
+    "2": "BX",
+    "3": "BK",
+    "4": "QN",
+    "5": "SI",
+  };
+
+  return hasOwnProperty(boroughs, id) ? boroughs[id] : "";
+};

--- a/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
@@ -15,6 +15,7 @@ import { ArrowBackIcon } from "@chakra-ui/icons";
 import { Indicator } from "@components/Indicator";
 import { CategoryMenu } from "@components/CategoryMenu";
 import { GeographyInfo } from "@components/GeographyInfo";
+import { DataDownloadModal } from "@components/DataDownloadModal";
 import { ExplorerSideNav } from "@components/ExplorerSideNav";
 import { useDataExplorerState } from "@hooks/useDataExplorerState";
 import { Category } from "@constants/Category";
@@ -179,7 +180,6 @@ const DataPage = ({
             direction={"row"}
             justifyContent={"space-between"}
             paddingX={{ base: "0.75rem", md: "1rem" }}
-            marginBottom={"1rem"}
           >
             <Box
               as="a"
@@ -190,6 +190,11 @@ const DataPage = ({
               <ArrowBackIcon w={"1.5rem"} h={"1.5rem"} color={"gray.600"} />
               back to map
             </Box>
+            <DataDownloadModal
+              downloadType={"data"}
+              geoid={geoid}
+              geography={geography}
+            />
           </Flex>
           <GeographyInfo
             geoid={geoid}


### PR DESCRIPTION
### Summary
This PR adds back the download button on the Community Data pages and updates `DataDownloadModal` with the logic to look up the correct file in DO. Note that the PDF option is disabled for now, until we have those file uploaded.

#### Tasks/Bug Numbers
 - Fixes [AB#7345](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7345)

### Technical Explanation
In our DO space for this project, the files are stored in the "downloads" folder. PUMA files follow the convention `<geoid>_xlxs.zip`, boroughs follow `<abbreviation>_xlxs.zip` where "abbreviation" is the two letter abbreviation for the borough (SI, MN, etc), citywide is `citywide_xlxs.zip`.