### PR TITLE
7919 remove reliability toggle/add note on HOPD page

### DIFF
--- a/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
@@ -248,21 +248,26 @@ const DataPage = ({
               <Link href="/methods" textDecoration="underline">
                 Learn more about our data sources.
               </Link>
+              <br />
+              {category === Category.HOPD &&
+                "Data not available by race/ethnicity."}
             </Text>
           </Box>
-          <FormControl width={"auto"} display={"flex"} alignItems="center">
-            <Switch
-              colorScheme="teal"
-              isChecked={shouldShowReliability}
-              onChange={() => {
-                toggleReliability();
-              }}
-              id="show-reliability"
-            />
-            <FormLabel htmlFor="show-reliability" mb="0" ml={4}>
-              Show reliability data
-            </FormLabel>
-          </FormControl>
+          {category !== Category.HOPD && (
+            <FormControl width={"auto"} display={"flex"} alignItems="center">
+              <Switch
+                colorScheme="teal"
+                isChecked={shouldShowReliability}
+                onChange={() => {
+                  toggleReliability();
+                }}
+                id="show-reliability"
+              />
+              <FormLabel htmlFor="show-reliability" mb="0" ml={4}>
+                Show reliability data
+              </FormLabel>
+            </FormControl>
+          )}
         </Flex>
 
         <Box paddingLeft={{ base: "0.75rem", md: "1rem" }}>


### PR DESCRIPTION
### Summary

Try to keep this more non-technical, and provide a wide angle, simple explanation of the problem and solution.
   - What was wrong?
       - reliability toggle was displaying on the Housing Production page
   - What is the fix?
       -  Added conditionals for hiding the toggle on housing production and to display note regarding racial data
 

#### Tasks/Bug Numbers
 - Fixes [AB#7919](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7919)
[AB7919](https://dev.azure.com/NYCPlanning/ITD/_sprints/taskboard/Open%20Source%20Engineering/ITD/2022/Q2/Sprint%20H?workitem=7919)
<img width="1329" alt="bug-before-fix" src="https://user-images.githubusercontent.com/11340947/162768128-25af099b-73e4-4065-88aa-1584bf874f72.png">

<img width="1306" alt="bug-after-fix" src="https://user-images.githubusercontent.com/11340947/162768089-00d8fe46-5ff4-48c0-87b9-086f6eedf915.png">



