### PR TITLE
7922 change left positioning to 1rem

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -50,7 +50,7 @@ export const Map = ({ layers, parent }: MapProps) => {
         left={{
           base: "2vmin",
           sm: "4vmin",
-          md: "2.1875rem",
+          md: "1rem",
         }}
       >
         <NavigationControl />

--- a/src/components/Map/ViewToggle.tsx
+++ b/src/components/Map/ViewToggle.tsx
@@ -71,7 +71,7 @@ export const ViewToggle = ({
       <ToggleButtonGroup
         position="absolute"
         top="1rem"
-        left="2.1875rem"
+        left="1rem"
         zIndex={200}
         boxShadow="lg"
         display={{

--- a/src/pages/map/[view]/[geography].tsx
+++ b/src/pages/map/[view]/[geography].tsx
@@ -237,7 +237,7 @@ const MapPage = ({ initialRouteParams }: MapPageProps) => {
               left={{
                 base: "2vmin",
                 sm: "4vmin",
-                md: "2.1875rem",
+                md: "1rem",
               }}
               zIndex={100}
               boxShadow="lg"


### PR DESCRIPTION
### Summary
Left positioning for the map navigation tools was too large at 35px and should have been only 16px.

#### Tasks/Bug Numbers
 - Fixes [AB#7922](https://dev.azure.com/NYCPlanning/ITD/_sprints/taskboard/Open%20Source%20Engineering/ITD/2022/Q2/Sprint%20H?workitem=7922)



### Technical Explanation
In the files/lines below, the left positioning was changed from `2.1875rem` to `1rem`
 - `ViewToggle.tsx`, line 74
  - `/pages/map/[view]/[geography].tsx`, line 240
  -  `Map.tsx`, line 53
<img width="978" alt="before" src="https://user-images.githubusercontent.com/11340947/162814878-9d47a3b0-eaa3-4351-ae12-5fbb160ef83f.png">

<img width="1068" alt="After" src="https://user-images.githubusercontent.com/11340947/162814888-1e86b6b1-ab40-4dc8-a351-84f01b351bdb.png">

