### PR TITLE
Add Secure attribute to GA init call

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -10,7 +10,7 @@ import ReactGA from "react-ga4";
 import { useRouter } from "next/router";
 
 function MyApp({ Component, pageProps }: AppProps) {
-  ReactGA.initialize("G-DEJNY15B0G");
+  ReactGA.initialize("G-DEJNY15B0G", { gaOptions: { cookieFlags: "Secure" } });
 
   const router = useRouter();
 


### PR DESCRIPTION
### Summary
This PR just adds a config option to the Google Analytics init function to add the "Secure" flag to the Cookie because it was causing a medium-severity vulnerability to show up in our app scans without it

#### Tasks/Bug Numbers
 - Fixes [AB#8000](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8000)
