### PR TITLE
7920 Expand and Collapse all tables on mobile

### DIFF
--- a/cypress/integration/pages/data.geography.geoid.category/subgroup.spec.ts
+++ b/cypress/integration/pages/data.geography.geoid.category/subgroup.spec.ts
@@ -25,6 +25,26 @@ describe("data/geography/geoid/category/subgroup page", () => {
       cy.url().should("include", "/map/data/borough?geoid=1");
     });
   });
+
+  context("mobile", () => {
+    beforeEach(() => {
+      cy.viewport(600, 2000);
+    });
+
+    it("users can expand and collapse all tables", () => {
+      cy.visit("data/district/4107/econ/tot");
+
+      cy.get("tbody").should("be.visible");
+
+      cy.get('[data-cy="collapseAllTables"]').click();
+
+      cy.get("tbody").should("not.be.visible");
+
+      cy.get('[data-cy="expandAllTables"]').click();
+
+      cy.get("tbody").should("be.visible");
+    });
+  });
 });
 
 export {};

--- a/src/components/VintageTable/VintageTable.tsx
+++ b/src/components/VintageTable/VintageTable.tsx
@@ -1,19 +1,10 @@
-import { forwardRef } from "react";
-import {
-  Flex,
-  Box,
-  Text,
-  Table,
-  Thead,
-  Tbody,
-  Th,
-  Tr,
-  useDisclosure,
-} from "@chakra-ui/react";
+/* eslint-disable react/display-name */
+import { forwardRef, useState } from "react";
+import { Flex, Box, Text, Table, Thead, Tbody, Th, Tr } from "@chakra-ui/react";
 import { ChevronDownIcon } from "@chakra-ui/icons";
 import { DataPointRow } from "@components/DataPointRow";
 import { Vintage } from "@schemas/vintage";
-
+import TablesIsOpenContext from "@contexts/TablesIsOpenContext";
 export interface VintageTableProps {
   vintage: Vintage;
   rowHeights: number[];
@@ -24,176 +15,217 @@ export interface VintageTableProps {
 export const VintageTable = forwardRef<HTMLTableElement, VintageTableProps>(
   ({ vintage, rowHeights, shouldShowReliability, isSurvey }, ref) => {
     const { rows, headers, label } = vintage;
-    const { isOpen, onToggle } = useDisclosure({
-      defaultIsOpen: true,
-    });
+    const [isOpen, setIsOpen] = useState(true);
 
     return (
-      <Table
-        variant="striped"
-        ref={ref}
-        sx={{
-          paddingRight: { base: 3, md: 0 },
-          display: "block",
-          overflowX: { base: "auto", md: "initial" },
-          borderCollapse: "initial",
-          borderSpacing: 0,
-          fontSize: "0.875rem",
-          tableLayout: "fixed",
-          width: "auto",
-          // These styles hide the row labels for all vintages after the first
-          // on desktop. Because vintages stack horizontally on desktop, we only need to
-          // render the labels once.
-          "&:not(:first-of-type)": {
-            "tbody tr th": {
-              display: { base: "table-cell", md: "none" },
-            },
-            "thead tr:first-of-type th:first-of-type": {
-              display: "none",
-            },
-          },
-        }}
-      >
-        <Thead>
-          <Tr>
-            <Th
-              rowSpan={headers.length + 1}
-              display={{ base: "none", md: "table-cell" }}
-              minWidth={"13.5rem"}
-              maxWidth={"13.5rem"}
-              borderTopLeftRadius={"0.75rem"}
-              border={"none"}
-            ></Th>
-            <Th
-              onClick={onToggle}
-              colSpan={6}
-              borderTopLeftRadius={{ base: "0.75rem", md: "0rem" }}
-              borderTopRightRadius={{ base: "0.75rem", md: "0rem" }}
-              borderBottomLeftRadius={{
-                base: isOpen ? "0rem" : "0.75rem",
-                md: "0rem",
-              }}
-              borderBottomRightRadius={{
-                base: isOpen ? "0rem" : "0.75rem",
-                md: "0rem",
-              }}
-              px={"1rem"}
-              minWidth={{
-                base: "calc(100vw - 26px)",
-                md: isSurvey && shouldShowReliability ? "30.5rem" : "15.375rem",
-              }}
-              maxWidth={{
-                base: "calc(100vw - 26px)",
-                md: isSurvey && shouldShowReliability ? "30.5rem" : "15.375rem",
-              }}
-            >
-              <Flex
-                justifyContent={"center"}
-                align={"center"}
-                position={"relative"}
-              >
-                <Box px={{ base: "4.5rem", md: "0rem" }}>
-                  <Text>{label}</Text>
-                </Box>
-                <Box
-                  display={{ base: "block", md: "none" }}
-                  position={"absolute"}
-                  right={"0rem"}
-                >
-                  <ChevronDownIcon
-                    transform={`rotate(${isOpen ? "0deg" : "-90deg"})`}
-                    color="teal.600"
-                    _hover={{ color: "teal.600" }}
-                    w={"2.5rem"}
-                    h={"2.5rem"}
-                  />
-                </Box>
-              </Flex>
-            </Th>
-          </Tr>
-          {/* If indicator data is a survey and shouldShowReliability is false,
-          just render first row of headers with colspan of 1 */}
-          {isSurvey && !shouldShowReliability ? (
-            <Tr
-              display={{ base: isOpen ? "table-row" : "none", md: "table-row" }}
-            >
-              <Th
-                rowSpan={headers.length}
-                display={{ base: "table-cell", md: "none" }}
-                position={"sticky"}
-                left={"0"}
-                zIndex={"100"}
-                minWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
-                maxWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
-              >
-                data
-              </Th>
+      <TablesIsOpenContext.Consumer>
+        {({ addSetIsOpen }) => {
+          addSetIsOpen(setIsOpen);
 
-              {headers[0].map((headerCell, j) => (
-                <Th
-                  colSpan={1}
-                  minWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
-                  maxWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
-                  key={`header-cell-${j}`}
-                >
-                  {headerCell.label}
-                </Th>
-              ))}
-            </Tr>
-          ) : (
-            // Otherwise, render all header rows, taking colspans from the data
-            headers.map((headerRow, i, headers) => (
-              <Tr
-                display={{
-                  base: isOpen ? "table-row" : "none",
-                  md: "table-row",
-                }}
-                key={`header-row-${i}`}
-              >
-                {i === 0 && (
+          return (
+            <Table
+              variant="striped"
+              ref={ref}
+              sx={{
+                paddingRight: { base: 3, md: 0 },
+                display: "block",
+                overflowX: { base: "auto", md: "initial" },
+                borderCollapse: "initial",
+                borderSpacing: 0,
+                fontSize: "0.875rem",
+                tableLayout: "fixed",
+                width: "auto",
+                // These styles hide the row labels for all vintages after the first
+                // on desktop. Because vintages stack horizontally on desktop, we only need to
+                // render the labels once.
+                "&:not(:first-of-type)": {
+                  "tbody tr th": {
+                    display: { base: "table-cell", md: "none" },
+                  },
+                  "thead tr:first-of-type th:first-of-type": {
+                    display: "none",
+                  },
+                },
+              }}
+            >
+              <Thead>
+                <Tr>
                   <Th
-                    rowSpan={headers.length}
-                    display={{ base: "table-cell", md: "none" }}
-                    position={"sticky"}
-                    left={"0"}
-                    zIndex={"100"}
-                    minWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
-                    maxWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
+                    rowSpan={headers.length + 1}
+                    display={{ base: "none", md: "table-cell" }}
+                    minWidth={"13.5rem"}
+                    maxWidth={"13.5rem"}
+                    borderTopLeftRadius={"0.75rem"}
+                    border={"none"}
+                  ></Th>
+                  <Th
+                    onClick={() => {
+                      setIsOpen(!isOpen);
+                    }}
+                    colSpan={6}
+                    borderTopLeftRadius={{ base: "0.75rem", md: "0rem" }}
+                    borderTopRightRadius={{ base: "0.75rem", md: "0rem" }}
+                    borderBottomLeftRadius={{
+                      base: isOpen ? "0rem" : "0.75rem",
+                      md: "0rem",
+                    }}
+                    borderBottomRightRadius={{
+                      base: isOpen ? "0rem" : "0.75rem",
+                      md: "0rem",
+                    }}
+                    px={"1rem"}
+                    minWidth={{
+                      base: "calc(100vw - 26px)",
+                      md:
+                        isSurvey && shouldShowReliability
+                          ? "30.5rem"
+                          : "15.375rem",
+                    }}
+                    maxWidth={{
+                      base: "calc(100vw - 26px)",
+                      md:
+                        isSurvey && shouldShowReliability
+                          ? "30.5rem"
+                          : "15.375rem",
+                    }}
                   >
-                    data
+                    <Flex
+                      justifyContent={"center"}
+                      align={"center"}
+                      position={"relative"}
+                    >
+                      <Box px={{ base: "4.5rem", md: "0rem" }}>
+                        <Text>{label}</Text>
+                      </Box>
+                      <Box
+                        display={{ base: "block", md: "none" }}
+                        position={"absolute"}
+                        right={"0rem"}
+                      >
+                        <ChevronDownIcon
+                          transform={`rotate(${isOpen ? "0deg" : "-90deg"})`}
+                          color="teal.600"
+                          _hover={{ color: "teal.600" }}
+                          w={"2.5rem"}
+                          h={"2.5rem"}
+                        />
+                      </Box>
+                    </Flex>
                   </Th>
+                </Tr>
+                {/* If indicator data is a survey and shouldShowReliability is false,
+                      just render first row of headers with colspan of 1 */}
+                {isSurvey && !shouldShowReliability ? (
+                  <Tr
+                    display={{
+                      base: isOpen ? "table-row" : "none",
+                      md: "table-row",
+                    }}
+                  >
+                    <Th
+                      rowSpan={headers.length}
+                      display={{ base: "table-cell", md: "none" }}
+                      position={"sticky"}
+                      left={"0"}
+                      zIndex={"100"}
+                      minWidth={{
+                        base: "calc((100vw - 26px) / 3)",
+                        md: "unset",
+                      }}
+                      maxWidth={{
+                        base: "calc((100vw - 26px) / 3)",
+                        md: "unset",
+                      }}
+                    >
+                      data
+                    </Th>
+
+                    {headers[0].map((headerCell, j) => (
+                      <Th
+                        colSpan={1}
+                        minWidth={{
+                          base: "calc((100vw - 26px) / 3)",
+                          md: "unset",
+                        }}
+                        maxWidth={{
+                          base: "calc((100vw - 26px) / 3)",
+                          md: "unset",
+                        }}
+                        key={`header-cell-${j}`}
+                      >
+                        {headerCell.label}
+                      </Th>
+                    ))}
+                  </Tr>
+                ) : (
+                  // Otherwise, render all header rows, taking colspans from the data
+                  headers.map((headerRow, i, headers) => (
+                    <Tr
+                      display={{
+                        base: isOpen ? "table-row" : "none",
+                        md: "table-row",
+                      }}
+                      key={`header-row-${i}`}
+                    >
+                      {i === 0 && (
+                        <Th
+                          rowSpan={headers.length}
+                          display={{ base: "table-cell", md: "none" }}
+                          position={"sticky"}
+                          left={"0"}
+                          zIndex={"100"}
+                          minWidth={{
+                            base: "calc((100vw - 26px) / 3)",
+                            md: "unset",
+                          }}
+                          maxWidth={{
+                            base: "calc((100vw - 26px) / 3)",
+                            md: "unset",
+                          }}
+                        >
+                          data
+                        </Th>
+                      )}
+
+                      {headerRow.map((headerCell, j) => (
+                        <Th
+                          colSpan={headerCell.colspan}
+                          minWidth={{
+                            base: "calc((100vw - 26px) / 3)",
+                            md: "unset",
+                          }}
+                          maxWidth={{
+                            base: "calc((100vw - 26px) / 3)",
+                            md: "unset",
+                          }}
+                          key={`header-cell-${j}`}
+                        >
+                          {headerCell.label}
+                        </Th>
+                      ))}
+                    </Tr>
+                  ))
                 )}
-
-                {headerRow.map((headerCell, j) => (
-                  <Th
-                    colSpan={headerCell.colspan}
-                    minWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
-                    maxWidth={{ base: "calc((100vw - 26px) / 3)", md: "unset" }}
-                    key={`header-cell-${j}`}
-                  >
-                    {headerCell.label}
-                  </Th>
+              </Thead>
+              <Tbody
+                display={{
+                  base: isOpen ? "table-row-group" : "none",
+                  md: "table-row-group",
+                }}
+              >
+                {rows.map((row, i) => (
+                  <DataPointRow
+                    shouldShowReliability={shouldShowReliability}
+                    height={rowHeights[i]}
+                    key={i}
+                    row={row}
+                  />
                 ))}
-              </Tr>
-            ))
-          )}
-        </Thead>
-        <Tbody
-          display={{
-            base: isOpen ? "table-row-group" : "none",
-            md: "table-row-group",
-          }}
-        >
-          {rows.map((row, i) => (
-            <DataPointRow
-              shouldShowReliability={shouldShowReliability}
-              height={rowHeights[i]}
-              key={i}
-              row={row}
-            />
-          ))}
-        </Tbody>
-      </Table>
+              </Tbody>
+            </Table>
+          );
+        }}
+      </TablesIsOpenContext.Consumer>
     );
   }
 );

--- a/src/components/VintageTable/VintageTable.tsx
+++ b/src/components/VintageTable/VintageTable.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/display-name */
-import { forwardRef, useState } from "react";
+import { forwardRef, useContext, useState } from "react";
 import { Flex, Box, Text, Table, Thead, Tbody, Th, Tr } from "@chakra-ui/react";
 import { ChevronDownIcon } from "@chakra-ui/icons";
 import { DataPointRow } from "@components/DataPointRow";
@@ -17,215 +17,205 @@ export const VintageTable = forwardRef<HTMLTableElement, VintageTableProps>(
     const { rows, headers, label } = vintage;
     const [isOpen, setIsOpen] = useState(true);
 
-    return (
-      <TablesIsOpenContext.Consumer>
-        {({ addSetIsOpen }) => {
-          addSetIsOpen(setIsOpen);
+    const { addSetIsOpen } = useContext(TablesIsOpenContext);
 
-          return (
-            <Table
-              variant="striped"
-              ref={ref}
-              sx={{
-                paddingRight: { base: 3, md: 0 },
-                display: "block",
-                overflowX: { base: "auto", md: "initial" },
-                borderCollapse: "initial",
-                borderSpacing: 0,
-                fontSize: "0.875rem",
-                tableLayout: "fixed",
-                width: "auto",
-                // These styles hide the row labels for all vintages after the first
-                // on desktop. Because vintages stack horizontally on desktop, we only need to
-                // render the labels once.
-                "&:not(:first-of-type)": {
-                  "tbody tr th": {
-                    display: { base: "table-cell", md: "none" },
-                  },
-                  "thead tr:first-of-type th:first-of-type": {
-                    display: "none",
-                  },
-                },
+    addSetIsOpen(setIsOpen);
+
+    return (
+      <Table
+        variant="striped"
+        ref={ref}
+        sx={{
+          paddingRight: { base: 3, md: 0 },
+          display: "block",
+          overflowX: { base: "auto", md: "initial" },
+          borderCollapse: "initial",
+          borderSpacing: 0,
+          fontSize: "0.875rem",
+          tableLayout: "fixed",
+          width: "auto",
+          // These styles hide the row labels for all vintages after the first
+          // on desktop. Because vintages stack horizontally on desktop, we only need to
+          // render the labels once.
+          "&:not(:first-of-type)": {
+            "tbody tr th": {
+              display: { base: "table-cell", md: "none" },
+            },
+            "thead tr:first-of-type th:first-of-type": {
+              display: "none",
+            },
+          },
+        }}
+      >
+        <Thead>
+          <Tr>
+            <Th
+              rowSpan={headers.length + 1}
+              display={{ base: "none", md: "table-cell" }}
+              minWidth={"13.5rem"}
+              maxWidth={"13.5rem"}
+              borderTopLeftRadius={"0.75rem"}
+              border={"none"}
+            ></Th>
+            <Th
+              onClick={() => {
+                setIsOpen(!isOpen);
+              }}
+              colSpan={6}
+              borderTopLeftRadius={{ base: "0.75rem", md: "0rem" }}
+              borderTopRightRadius={{ base: "0.75rem", md: "0rem" }}
+              borderBottomLeftRadius={{
+                base: isOpen ? "0rem" : "0.75rem",
+                md: "0rem",
+              }}
+              borderBottomRightRadius={{
+                base: isOpen ? "0rem" : "0.75rem",
+                md: "0rem",
+              }}
+              px={"1rem"}
+              minWidth={{
+                base: "calc(100vw - 26px)",
+                md: isSurvey && shouldShowReliability ? "30.5rem" : "15.375rem",
+              }}
+              maxWidth={{
+                base: "calc(100vw - 26px)",
+                md: isSurvey && shouldShowReliability ? "30.5rem" : "15.375rem",
               }}
             >
-              <Thead>
-                <Tr>
-                  <Th
-                    rowSpan={headers.length + 1}
-                    display={{ base: "none", md: "table-cell" }}
-                    minWidth={"13.5rem"}
-                    maxWidth={"13.5rem"}
-                    borderTopLeftRadius={"0.75rem"}
-                    border={"none"}
-                  ></Th>
-                  <Th
-                    onClick={() => {
-                      setIsOpen(!isOpen);
-                    }}
-                    colSpan={6}
-                    borderTopLeftRadius={{ base: "0.75rem", md: "0rem" }}
-                    borderTopRightRadius={{ base: "0.75rem", md: "0rem" }}
-                    borderBottomLeftRadius={{
-                      base: isOpen ? "0rem" : "0.75rem",
-                      md: "0rem",
-                    }}
-                    borderBottomRightRadius={{
-                      base: isOpen ? "0rem" : "0.75rem",
-                      md: "0rem",
-                    }}
-                    px={"1rem"}
-                    minWidth={{
-                      base: "calc(100vw - 26px)",
-                      md:
-                        isSurvey && shouldShowReliability
-                          ? "30.5rem"
-                          : "15.375rem",
-                    }}
-                    maxWidth={{
-                      base: "calc(100vw - 26px)",
-                      md:
-                        isSurvey && shouldShowReliability
-                          ? "30.5rem"
-                          : "15.375rem",
-                    }}
-                  >
-                    <Flex
-                      justifyContent={"center"}
-                      align={"center"}
-                      position={"relative"}
-                    >
-                      <Box px={{ base: "4.5rem", md: "0rem" }}>
-                        <Text>{label}</Text>
-                      </Box>
-                      <Box
-                        display={{ base: "block", md: "none" }}
-                        position={"absolute"}
-                        right={"0rem"}
-                      >
-                        <ChevronDownIcon
-                          transform={`rotate(${isOpen ? "0deg" : "-90deg"})`}
-                          color="teal.600"
-                          _hover={{ color: "teal.600" }}
-                          w={"2.5rem"}
-                          h={"2.5rem"}
-                        />
-                      </Box>
-                    </Flex>
-                  </Th>
-                </Tr>
-                {/* If indicator data is a survey and shouldShowReliability is false,
-                      just render first row of headers with colspan of 1 */}
-                {isSurvey && !shouldShowReliability ? (
-                  <Tr
-                    display={{
-                      base: isOpen ? "table-row" : "none",
-                      md: "table-row",
-                    }}
-                  >
-                    <Th
-                      rowSpan={headers.length}
-                      display={{ base: "table-cell", md: "none" }}
-                      position={"sticky"}
-                      left={"0"}
-                      zIndex={"100"}
-                      minWidth={{
-                        base: "calc((100vw - 26px) / 3)",
-                        md: "unset",
-                      }}
-                      maxWidth={{
-                        base: "calc((100vw - 26px) / 3)",
-                        md: "unset",
-                      }}
-                    >
-                      data
-                    </Th>
-
-                    {headers[0].map((headerCell, j) => (
-                      <Th
-                        colSpan={1}
-                        minWidth={{
-                          base: "calc((100vw - 26px) / 3)",
-                          md: "unset",
-                        }}
-                        maxWidth={{
-                          base: "calc((100vw - 26px) / 3)",
-                          md: "unset",
-                        }}
-                        key={`header-cell-${j}`}
-                      >
-                        {headerCell.label}
-                      </Th>
-                    ))}
-                  </Tr>
-                ) : (
-                  // Otherwise, render all header rows, taking colspans from the data
-                  headers.map((headerRow, i, headers) => (
-                    <Tr
-                      display={{
-                        base: isOpen ? "table-row" : "none",
-                        md: "table-row",
-                      }}
-                      key={`header-row-${i}`}
-                    >
-                      {i === 0 && (
-                        <Th
-                          rowSpan={headers.length}
-                          display={{ base: "table-cell", md: "none" }}
-                          position={"sticky"}
-                          left={"0"}
-                          zIndex={"100"}
-                          minWidth={{
-                            base: "calc((100vw - 26px) / 3)",
-                            md: "unset",
-                          }}
-                          maxWidth={{
-                            base: "calc((100vw - 26px) / 3)",
-                            md: "unset",
-                          }}
-                        >
-                          data
-                        </Th>
-                      )}
-
-                      {headerRow.map((headerCell, j) => (
-                        <Th
-                          colSpan={headerCell.colspan}
-                          minWidth={{
-                            base: "calc((100vw - 26px) / 3)",
-                            md: "unset",
-                          }}
-                          maxWidth={{
-                            base: "calc((100vw - 26px) / 3)",
-                            md: "unset",
-                          }}
-                          key={`header-cell-${j}`}
-                        >
-                          {headerCell.label}
-                        </Th>
-                      ))}
-                    </Tr>
-                  ))
-                )}
-              </Thead>
-              <Tbody
-                display={{
-                  base: isOpen ? "table-row-group" : "none",
-                  md: "table-row-group",
+              <Flex
+                justifyContent={"center"}
+                align={"center"}
+                position={"relative"}
+              >
+                <Box px={{ base: "4.5rem", md: "0rem" }}>
+                  <Text>{label}</Text>
+                </Box>
+                <Box
+                  display={{ base: "block", md: "none" }}
+                  position={"absolute"}
+                  right={"0rem"}
+                >
+                  <ChevronDownIcon
+                    transform={`rotate(${isOpen ? "0deg" : "-90deg"})`}
+                    color="teal.600"
+                    _hover={{ color: "teal.600" }}
+                    w={"2.5rem"}
+                    h={"2.5rem"}
+                  />
+                </Box>
+              </Flex>
+            </Th>
+          </Tr>
+          {/* If indicator data is a survey and shouldShowReliability is false,
+                just render first row of headers with colspan of 1 */}
+          {isSurvey && !shouldShowReliability ? (
+            <Tr
+              display={{
+                base: isOpen ? "table-row" : "none",
+                md: "table-row",
+              }}
+            >
+              <Th
+                rowSpan={headers.length}
+                display={{ base: "table-cell", md: "none" }}
+                position={"sticky"}
+                left={"0"}
+                zIndex={"100"}
+                minWidth={{
+                  base: "calc((100vw - 26px) / 3)",
+                  md: "unset",
+                }}
+                maxWidth={{
+                  base: "calc((100vw - 26px) / 3)",
+                  md: "unset",
                 }}
               >
-                {rows.map((row, i) => (
-                  <DataPointRow
-                    shouldShowReliability={shouldShowReliability}
-                    height={rowHeights[i]}
-                    key={i}
-                    row={row}
-                  />
+                data
+              </Th>
+
+              {headers[0].map((headerCell, j) => (
+                <Th
+                  colSpan={1}
+                  minWidth={{
+                    base: "calc((100vw - 26px) / 3)",
+                    md: "unset",
+                  }}
+                  maxWidth={{
+                    base: "calc((100vw - 26px) / 3)",
+                    md: "unset",
+                  }}
+                  key={`header-cell-${j}`}
+                >
+                  {headerCell.label}
+                </Th>
+              ))}
+            </Tr>
+          ) : (
+            // Otherwise, render all header rows, taking colspans from the data
+            headers.map((headerRow, i, headers) => (
+              <Tr
+                display={{
+                  base: isOpen ? "table-row" : "none",
+                  md: "table-row",
+                }}
+                key={`header-row-${i}`}
+              >
+                {i === 0 && (
+                  <Th
+                    rowSpan={headers.length}
+                    display={{ base: "table-cell", md: "none" }}
+                    position={"sticky"}
+                    left={"0"}
+                    zIndex={"100"}
+                    minWidth={{
+                      base: "calc((100vw - 26px) / 3)",
+                      md: "unset",
+                    }}
+                    maxWidth={{
+                      base: "calc((100vw - 26px) / 3)",
+                      md: "unset",
+                    }}
+                  >
+                    data
+                  </Th>
+                )}
+
+                {headerRow.map((headerCell, j) => (
+                  <Th
+                    colSpan={headerCell.colspan}
+                    minWidth={{
+                      base: "calc((100vw - 26px) / 3)",
+                      md: "unset",
+                    }}
+                    maxWidth={{
+                      base: "calc((100vw - 26px) / 3)",
+                      md: "unset",
+                    }}
+                    key={`header-cell-${j}`}
+                  >
+                    {headerCell.label}
+                  </Th>
                 ))}
-              </Tbody>
-            </Table>
-          );
-        }}
-      </TablesIsOpenContext.Consumer>
+              </Tr>
+            ))
+          )}
+        </Thead>
+        <Tbody
+          display={{
+            base: isOpen ? "table-row-group" : "none",
+            md: "table-row-group",
+          }}
+        >
+          {rows.map((row, i) => (
+            <DataPointRow
+              shouldShowReliability={shouldShowReliability}
+              height={rowHeights[i]}
+              key={i}
+              row={row}
+            />
+          ))}
+        </Tbody>
+      </Table>
     );
   }
 );

--- a/src/components/VintageTable/VintageTable.tsx
+++ b/src/components/VintageTable/VintageTable.tsx
@@ -1,9 +1,9 @@
-import { forwardRef, useContext, useState } from "react";
+import { forwardRef, useState } from "react";
 import { Flex, Box, Text, Table, Thead, Tbody, Th, Tr } from "@chakra-ui/react";
 import { ChevronDownIcon } from "@chakra-ui/icons";
 import { DataPointRow } from "@components/DataPointRow";
 import { Vintage } from "@schemas/vintage";
-import TablesIsOpenContext from "@contexts/TablesIsOpenContext";
+import { useTablesIsOpen } from "@contexts/TablesIsOpenContext";
 export interface VintageTableProps {
   vintage: Vintage;
   rowHeights: number[];
@@ -16,7 +16,7 @@ const VintageTable = forwardRef<HTMLTableElement, VintageTableProps>(
     const { rows, headers, label } = vintage;
     const [isOpen, setIsOpen] = useState(true);
 
-    const { addSetIsOpen } = useContext(TablesIsOpenContext);
+    const { addSetIsOpen } = useTablesIsOpen();
 
     addSetIsOpen(setIsOpen);
 

--- a/src/components/VintageTable/VintageTable.tsx
+++ b/src/components/VintageTable/VintageTable.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/display-name */
 import { forwardRef, useContext, useState } from "react";
 import { Flex, Box, Text, Table, Thead, Tbody, Th, Tr } from "@chakra-ui/react";
 import { ChevronDownIcon } from "@chakra-ui/icons";
@@ -12,7 +11,7 @@ export interface VintageTableProps {
   isSurvey: boolean;
 }
 
-export const VintageTable = forwardRef<HTMLTableElement, VintageTableProps>(
+const VintageTable = forwardRef<HTMLTableElement, VintageTableProps>(
   ({ vintage, rowHeights, shouldShowReliability, isSurvey }, ref) => {
     const { rows, headers, label } = vintage;
     const [isOpen, setIsOpen] = useState(true);
@@ -219,3 +218,7 @@ export const VintageTable = forwardRef<HTMLTableElement, VintageTableProps>(
     );
   }
 );
+
+VintageTable.displayName = "VintageTable";
+
+export { VintageTable };

--- a/src/contexts/TablesIsOpenContext.ts
+++ b/src/contexts/TablesIsOpenContext.ts
@@ -1,9 +1,0 @@
-import { createContext } from "react";
-
-const TablesIsOpenContext = createContext({
-  addSetIsOpen: (dispatch: React.Dispatch<boolean>): void => {
-    console.log(dispatch);
-  },
-});
-
-export default TablesIsOpenContext;

--- a/src/contexts/TablesIsOpenContext.ts
+++ b/src/contexts/TablesIsOpenContext.ts
@@ -1,0 +1,9 @@
+import { createContext } from "react";
+
+const TablesIsOpenContext = createContext({
+  addSetIsOpen: (dispatch: React.Dispatch<boolean>): void => {
+    console.log(dispatch);
+  },
+});
+
+export default TablesIsOpenContext;

--- a/src/contexts/TablesIsOpenContext.tsx
+++ b/src/contexts/TablesIsOpenContext.tsx
@@ -1,0 +1,41 @@
+import React, { createContext, useContext } from "react";
+
+interface TablesIsOpenProviderProps {
+  children: React.ReactNode;
+  tablesSetIsOpens: React.Dispatch<boolean>[];
+}
+
+const TablesIsOpenContext = createContext<
+  { addSetIsOpen: (dispatch: React.Dispatch<boolean>) => void } | undefined
+>(undefined);
+
+function TablesIsOpenProvider({
+  tablesSetIsOpens,
+  children,
+}: TablesIsOpenProviderProps) {
+  return (
+    <TablesIsOpenContext.Provider
+      value={{
+        addSetIsOpen: (setIsOpen: React.Dispatch<boolean>) => {
+          tablesSetIsOpens.push(setIsOpen);
+        },
+      }}
+    >
+      {children}
+    </TablesIsOpenContext.Provider>
+  );
+}
+
+function useTablesIsOpen() {
+  const tablesIsOpenContext = useContext(TablesIsOpenContext);
+
+  if (tablesIsOpenContext === undefined) {
+    throw new Error(
+      "useTablesIsOpen must be used within a TablesIsOpenProvider"
+    );
+  }
+
+  return tablesIsOpenContext;
+}
+
+export { TablesIsOpenProvider, useTablesIsOpen };

--- a/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
@@ -30,7 +30,7 @@ import ReactGA from "react-ga4";
 import { parseDataExplorerSelection } from "@helpers/parseDataExplorerSelection";
 import { Subgroup } from "@constants/Subgroup";
 import { hasOwnProperty } from "@helpers/hasOwnProperty";
-import TablesIsOpenContext from "@contexts/TablesIsOpenContext";
+import { TablesIsOpenProvider } from "@contexts/TablesIsOpenContext";
 
 export interface DataPageProps {
   hasRacialBreakdown: boolean;
@@ -152,12 +152,6 @@ const DataPage = ({
   const router = useRouter();
 
   const tablesSetIsOpens: React.Dispatch<boolean>[] = [];
-
-  const defaultTablesIsOpenContext = {
-    addSetIsOpen: (setIsOpen: React.Dispatch<boolean>) => {
-      tablesSetIsOpens.push(setIsOpen);
-    },
-  };
 
   const changeSubgroup = (event: any) => {
     router.push(
@@ -319,7 +313,7 @@ const DataPage = ({
         </HStack>
 
         <Box paddingLeft={{ base: "0.75rem", md: "1rem" }}>
-          <TablesIsOpenContext.Provider value={defaultTablesIsOpenContext}>
+          <TablesIsOpenProvider tablesSetIsOpens={tablesSetIsOpens}>
             {indicators.map((indicator, i) => (
               <Indicator
                 key={`indicator-${i}`}
@@ -327,7 +321,7 @@ const DataPage = ({
                 shouldShowReliability={shouldShowReliability}
               />
             ))}
-          </TablesIsOpenContext.Provider>
+          </TablesIsOpenProvider>
         </Box>
       </Box>
     </Flex>

--- a/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import React, { useState } from "react";
 import { GetStaticProps, GetStaticPaths } from "next";
 import {
   Box,
+  Button,
   Flex,
   Text,
   FormControl,
@@ -10,6 +11,7 @@ import {
   Select,
   Heading,
   Link,
+  HStack,
 } from "@chakra-ui/react";
 import { ArrowBackIcon } from "@chakra-ui/icons";
 import { Indicator } from "@components/Indicator";
@@ -28,6 +30,8 @@ import ReactGA from "react-ga4";
 import { parseDataExplorerSelection } from "@helpers/parseDataExplorerSelection";
 import { Subgroup } from "@constants/Subgroup";
 import { hasOwnProperty } from "@helpers/hasOwnProperty";
+import TablesIsOpenContext from "@contexts/TablesIsOpenContext";
+
 export interface DataPageProps {
   hasRacialBreakdown: boolean;
   indicators: IndicatorRecord[];
@@ -146,6 +150,15 @@ const DataPage = ({
     useState<boolean>(false);
   const { geography, geoid, category, subgroup } = useDataExplorerState();
   const router = useRouter();
+
+  const tablesSetIsOpens: React.Dispatch<boolean>[] = [];
+
+  const defaultTablesIsOpenContext = {
+    addSetIsOpen: (setIsOpen: React.Dispatch<boolean>) => {
+      tablesSetIsOpens.push(setIsOpen);
+    },
+  };
+
   const changeSubgroup = (event: any) => {
     router.push(
       `/data/${geography}/${geoid}/${category}/${event.target.value}`
@@ -271,15 +284,50 @@ const DataPage = ({
             </FormControl>
           )}
         </Flex>
+        <HStack
+          width="100%"
+          paddingX={{ base: "0.75rem", md: "1rem" }}
+          paddingTop={{ base: "0rem" }}
+          paddingBottom={{ base: "1rem", md: "0.75rem" }}
+          display={{
+            base: "auto",
+            md: "none",
+          }}
+        >
+          <Button
+            variant="outline"
+            fontWeight="400"
+            onClick={() => {
+              tablesSetIsOpens.forEach((setIsOpen) => {
+                setIsOpen(false);
+              });
+            }}
+          >
+            Collapse All Tables
+          </Button>
+          <Button
+            variant="outline"
+            fontWeight="400"
+            onClick={() => {
+              tablesSetIsOpens.forEach((setIsOpen) => {
+                setIsOpen(true);
+              });
+            }}
+          >
+            Expand All Tables
+          </Button>
+        </HStack>
 
         <Box paddingLeft={{ base: "0.75rem", md: "1rem" }}>
-          {indicators.map((indicator, i) => (
-            <Indicator
-              key={`indicator-${i}`}
-              indicator={indicator}
-              shouldShowReliability={shouldShowReliability}
-            />
-          ))}
+          <TablesIsOpenContext.Provider value={defaultTablesIsOpenContext}>
+            {indicators.map((indicator, i) => (
+              <Indicator
+                key={`indicator-${i}`}
+                indicator={indicator}
+                shouldShowReliability={shouldShowReliability}
+              />
+            ))}
+          </TablesIsOpenContext.Provider>
         </Box>
       </Box>
     </Flex>

--- a/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
@@ -296,6 +296,7 @@ const DataPage = ({
                 setIsOpen(false);
               });
             }}
+            data-cy="collapseAllTables"
           >
             Collapse All Tables
           </Button>
@@ -307,6 +308,7 @@ const DataPage = ({
                 setIsOpen(true);
               });
             }}
+            data-cy="expandAllTables"
           >
             Expand All Tables
           </Button>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,8 @@
       "@helpers/*": ["helpers/*"],
       "@constants/*": ["constants/*"],
       "@services/*": ["services/*"],
-      "@schemas/*": ["schemas/*"]
+      "@schemas/*": ["schemas/*"],
+      "@contexts/*": ["contexts/*"]
     }
   },
   "include": [


### PR DESCRIPTION
Fixes [AB#7920](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7920)

Introduces Expand All and Collapse All (table) buttons to the mobile view of the Data Explorer page. 

Here I made use of Contexts to avoid passing functions through multiple levels from `[subgroup]` down to `VintageTable`. 

The Context essentially acts as a binding between the state array `tableSetIsOpens` in `[subgroup]` and the `setIsOpen` Dispatches of each table.  `tableSetIsOpens` holds an array of `setIsOpen` dispatches from the tables. 

When a table is rendered, it will use the Context's `addSetIsOpen: ()` property  to push it's `setIsOpen` dispatch to the `tableSetIsOpens` array. 

![image](https://user-images.githubusercontent.com/3311663/162915617-eebc0867-960f-4a5f-b01c-069424320bd4.png)
