### PR TITLE
7917 fixes to overlapping text when browser window height decreases

### DIFF
--- a/src/components/SidebarContent/SidebarContent.tsx
+++ b/src/components/SidebarContent/SidebarContent.tsx
@@ -3,7 +3,6 @@ import { Box, Divider, Button, Flex } from "@chakra-ui/react";
 import { ArrowBackIcon } from "@chakra-ui/icons";
 import { GeographyInfo } from "@components/GeographyInfo";
 import WelcomeContent from "@components/WelcomeContent";
-import WelcomeFooter from "@components/WelcomeFooter";
 import { DRMSelection } from "@components/SidebarContent/DRMSelection";
 import { useMapSubrouteInfo } from "@hooks/useMapSubrouteInfo";
 import { useClearSelection } from "@helpers/useClearSelection";
@@ -80,14 +79,11 @@ export const SidebarContent = () => {
     <>
       <Box
         height="100%"
-        justify="space-between"
+        overflowY="auto"
         padding="2rem 1rem"
         paddingBottom="0rem"
       >
         <WelcomeContent />
-      </Box>
-      <Box padding="2rem 1rem" paddingTop="0rem">
-        <WelcomeFooter />
       </Box>
     </>
   );

--- a/src/components/WelcomeContent.tsx
+++ b/src/components/WelcomeContent.tsx
@@ -1,5 +1,6 @@
-import { Heading, Text, Link } from "@chakra-ui/react";
+import { Heading, Text, Link, Box } from "@chakra-ui/react";
 import { useMapSubrouteInfo } from "@hooks/useMapSubrouteInfo";
+import WelcomeFooter from "./WelcomeFooter";
 import ReactGA from "react-ga4";
 
 const WelcomeContent = () => {
@@ -30,6 +31,9 @@ const WelcomeContent = () => {
           see the level of risk residents face of being unable to remain in
           their homes or neighborhoods.
         </Text>
+        <Box paddingTop="2rem" display={{ base: "none", md: "block" }}>
+          <WelcomeFooter />
+        </Box>
       </>
     );
   }
@@ -78,6 +82,9 @@ const WelcomeContent = () => {
         </Text>
 
         <br />
+        <Box paddingTop="2rem" display={{ base: "none", md: "block" }}>
+          <WelcomeFooter />
+        </Box>
       </>
     );
   }

--- a/src/components/WelcomeFooter.tsx
+++ b/src/components/WelcomeFooter.tsx
@@ -7,7 +7,7 @@ const WelcomeFooter = () => {
 
   if (view === "data") {
     return (
-      <Box fontSize="0.8125rem">
+      <Box fontSize="0.8125rem" paddingBottom={{ base: "1rem", md: "unset" }}>
         <Text>
           *Community Districts are approximated using data from Public Use
           Microdata Areas (PUMAs).


### PR DESCRIPTION
 - moved welcome footer text to welcome content
 - enabled Y scrolling
 - added padding to welcome footer text on mobile screens
 - cleaned up unused code in welcome context after refactoring

#### Tasks/Bug Numbers
 - Fixes [AB#7917](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7917)

### Technical Explanation
The height for the `WelcomeContext` component was set to 100%  forcing the component to remain the same height at all vertical browser heights  which results in the `WelcomeFooter` text to overlap into and over the `WelcomeContext` text. By importing the `WelcomeFooter` into the `WelcomeContext` component rather than have them individually imported into the `SidebarContent` component, the overlapping text bug is avoided and the entire body of text scrolls as one unit. I also added a scrollbar to visually clue in the user that there is scrollable text.
  



