### PR TITLE
7974 updated year in about page racial equity section

### DIFF
--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -139,7 +139,7 @@ const AboutPage = () => (
             Racial Equity Reports
           </Heading>
           <Text pb="0.5em">
-            As of June 1, 2020,{" "}
+            As of June 1, 2022,{" "}
             <Link
               href="https://www1.nyc.gov//assets/planning/download/pdf/data-maps/edde/racial-equity-report-applicability-chart.pdf"
               color="teal"


### PR DESCRIPTION
Updated the year on the About page, racial Equity section from `2020` to `2022`

#### Tasks/Bug Numbers
 - Fixes [AB#7974](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7974)

