### PR TITLE
7955 Hyperlink text contains extra words

### DIFF
--- a/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
@@ -244,10 +244,12 @@ const DataPage = ({
               {heading}
             </Heading>
             <Text>
-              Note: Data shown in gray have poor statistical reliability.{" "}
+              Note: Data shown in gray have poor statistical reliability. Learn
+              more about our{" "}
               <Link href="/methods" textDecoration="underline">
-                Learn more about our data sources.
+                data sources
               </Link>
+              .
               <br />
               {category === Category.HOPD &&
                 "Data not available by race/ethnicity."}


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
Per[ Figma note](https://www.figma.com/file/U7dgahwMaggEmMI1l5O1Z9/Equitable-Development-Reporting---EDDE-Tool?node-id=7129:151650), the following text should be added to the top of the data explorer pages:

Expected

"Note: Data shown in gray have poor statistical reliability. Learn more about our data sources."

'data sources' should hyperlink to the Sources and Methods page


Actual

"Note: Data shown in gray have poor statistical reliability. Learn more about our data sources."

'Learn more about our data sources' is hyperlinked



#### Tasks/Bug Numbers
 - Fixes AB#7955

