### PR TITLE
7983 updated copy on SidebarContent/DRMSelection/DRMSelection.tsx

### DIFF
--- a/src/components/SidebarContent/DRMSelection/DRMSelection.tsx
+++ b/src/components/SidebarContent/DRMSelection/DRMSelection.tsx
@@ -61,13 +61,13 @@ export const DRMSelection = () => {
         />
         <Divider borderColor="gray.100" />
         <DataPoint
-          title="Housing NY &amp; NYC Housing Authority (NYCHA)"
+          title="Housing that is not Income-Restricted"
           value={selectedDRMdata?.percentunitswithnoincomerestrictions}
           percentage={true}
         />
         <Divider borderColor="gray.100" />
         <DataPoint
-          title="Rent-Stabilized Housing units"
+          title="Housing that is not Rent-Stabilized"
           value={selectedDRMdata?.percentunitswithrentregulationsvscity}
           percentage={false}
           noNumber={true}


### PR DESCRIPTION
Updated copy in categories in the Housing Conditions Index to clarify the nature of the data being displayed.
 - "HOUSING NY & NYC HOUSING AUTHORITY (NYCHA)" =>  "HOUSING THAT IS NOT INCOME-RESTRICTED" 
 - "RENT-STABILIZED HOUSING UNITS" => "HOUSING THAT IS NOT RENT-STABILIZED" 
`src/components/SidebarContent/DRMSelection/DRMSelection.tsx` lines 64 and 70

#### Tasks/Bug Numbers
 - Fixes [AB#7983](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7983)



