### PR TITLE
7854 [WEB] Nav Items Should adjust position when switching from CommData to DRM view

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -45,7 +45,7 @@ export const Map = ({ layers, parent }: MapProps) => {
         position="absolute"
         top={{
           base: view === "data" ? "4.5rem" : "1.3rem",
-          md: "8rem",
+          md: view === "data" ? "8rem" : "4.5rem",
         }}
         left={{
           base: "2vmin",


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
Per [Figma](https://www.figma.com/file/U7dgahwMaggEmMI1l5O1Z9/Equitable-Development-Reporting---EDDE-Tool?node-id=2874:55601), the map zoom + and - and north arrow UI element should move upward when switching from Community Data to DRM, as the geography select menu item is hidden. It should also automatically adjust back downward to accommodate the geography select menu when the toggle is returned to Community Data
![image](https://user-images.githubusercontent.com/61206501/162991900-6b994a6f-437b-4a2d-bed3-a2ed163c924c.png)


#### Tasks/Bug Numbers
 - Fixes AB#7854

