### PR TITLE
7917 adjustments to prevent text overlap …

### DIFF
--- a/src/components/SidebarContent/SidebarContent.tsx
+++ b/src/components/SidebarContent/SidebarContent.tsx
@@ -78,12 +78,7 @@ export const SidebarContent = () => {
 
   return (
     <>
-      <Box
-        height="100%"
-        justify="space-between"
-        padding="2rem 1rem"
-        paddingBottom="0rem"
-      >
+      <Box padding="2rem 1rem" paddingBottom="0rem">
         <WelcomeContent />
       </Box>
       <Box padding="2rem 1rem" paddingTop="0rem">

--- a/src/pages/map/[view]/[geography].tsx
+++ b/src/pages/map/[view]/[geography].tsx
@@ -209,6 +209,7 @@ const MapPage = ({ initialRouteParams }: MapPageProps) => {
             display: "none",
           },
         }}
+        justify="space-between"
         data-cy="desktopSidebar"
       >
         <SidebarContent />


### PR DESCRIPTION
CSS tweaks to prevent text overlap on browser / window heights less than 700px


#### Tasks/Bug Numbers
 - Fixes [AB#7917](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7917)

### Technical Explanation
The height for the `WelcomeContext` component was set to 100%  forcing the component to remain the same height at all vertical browser heights  which results in the `WelcomeFooter` text to overlap into and over the `WelcomeContext` text. 
 - removed justify and height attributes from the SidebarContent
 - added justify attribute to pages/map/[view]/[geography].