### PR TITLE
Add new PercentDataPointCell to split up logic and update logic to sh…

### DIFF
--- a/src/components/DataPointRow/DataPointRow.tsx
+++ b/src/components/DataPointRow/DataPointRow.tsx
@@ -1,6 +1,7 @@
 import { Tr, Td, TableRowProps } from "@chakra-ui/react";
 import { Row } from "@schemas/row";
 import { DataPointCell } from "@components/DataPointCell";
+import { PercentDataPointCell } from "@components/PercentDataPointCell.tsx";
 
 export interface DataPointRowProps extends TableRowProps {
   row: Row;
@@ -56,7 +57,7 @@ export const DataPointRow = ({
   }
 
   const cv = cells.find((dataPoint) => dataPoint.variance === "CV");
-  const isReliable = cv && cv.value !== null && cv.value >= 20 ? false : true;
+  const isReliable = cv && (cv.value === null || cv.value >= 20) ? false : true;
   return (
     <Tr
       {...props}
@@ -94,13 +95,21 @@ export const DataPointRow = ({
           // Otherwise, only show those with variance of "NONE"
           return dataPoint.variance === "NONE";
         })
-        .map((dataPoint, j) => (
-          <DataPointCell
-            key={`data-point-cell-${j}`}
-            dataPoint={dataPoint}
-            isReliable={isReliable}
-          />
-        ))}
+        .map((dataPoint, j) =>
+          dataPoint.measure === "PERCENT" ? (
+            <PercentDataPointCell
+              key={`data-point-cell-${j}`}
+              dataPoint={dataPoint}
+              isReliable={isReliable}
+            />
+          ) : (
+            <DataPointCell
+              key={`data-point-cell-${j}`}
+              dataPoint={dataPoint}
+              isReliable={isReliable}
+            />
+          )
+        )}
     </Tr>
   );
 };

--- a/src/components/PercentDataPointCell.tsx/PercentDataPointCell.tsx
+++ b/src/components/PercentDataPointCell.tsx/PercentDataPointCell.tsx
@@ -1,26 +1,25 @@
 import { Td } from "@chakra-ui/react";
 import { DataPoint } from "@schemas/dataPoint";
 
-export interface DataPointCellProps {
+export interface PercentDataPointCellProps {
   dataPoint: DataPoint;
   isReliable: boolean;
 }
 
-export const DataPointCell = ({
+export const PercentDataPointCell = ({
   dataPoint,
   isReliable,
-}: DataPointCellProps) => {
-  const { value, variance } = dataPoint;
-
+}: PercentDataPointCellProps) => {
+  const { value } = dataPoint;
   let formattedValue = "";
   if (value === null) {
-    formattedValue = variance === "NONE" ? "-" : "";
+    formattedValue = "";
   } else {
-    const roundTo = variance === "CV" ? 1 : 0;
-    formattedValue = value.toLocaleString(undefined, {
-      maximumFractionDigits: roundTo,
-      minimumFractionDigits: roundTo,
-    });
+    formattedValue =
+      value.toLocaleString(undefined, {
+        maximumFractionDigits: 1,
+        minimumFractionDigits: 1,
+      }) + "%";
   }
   return (
     <Td

--- a/src/components/PercentDataPointCell.tsx/index.ts
+++ b/src/components/PercentDataPointCell.tsx/index.ts
@@ -1,0 +1,1 @@
+export * from "./PercentDataPointCell";


### PR DESCRIPTION
### Summary
This PR updates the logic for how `dataPoint`s with null for `value` are displayed. I made a separate PercentDataPointCell component to help compartmentalize the logic between percent and percent moe's vs other datapoints. This PR also updates the logic for `isReliable` to be false when there is a CV datapoint but its value is null. At a high level, this change will result in CVs, MOEs (including percent moes), and percents displaying a blank cell when null, instead of a `-`.

#### Tasks/Bug Numbers
 - Fixes [AB#8004](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8004)
- Fixes [AB#7851](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7851)
- Fixes [AB#7847](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7847)
- Fixes [AB#7850](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7850)

<img width="728" alt="image" src="https://user-images.githubusercontent.com/9055367/163202283-9c6b32e4-9f45-4db9-a6be-21a5d7e6428a.png">

<img width="714" alt="image" src="https://user-images.githubusercontent.com/9055367/163202382-a89e88fa-361d-4f76-9e34-55ec1d91896d.png">

