### PR TITLE
7923 [WEB] Map Sidebar is too wide

### DIFF
--- a/src/pages/map/[view]/[geography].tsx
+++ b/src/pages/map/[view]/[geography].tsx
@@ -197,6 +197,10 @@ const MapPage = ({ initialRouteParams }: MapPageProps) => {
           base: "none",
           md: "flex",
         }}
+        maxWidth={{
+          base: "none",
+          md: "403px",
+        }}
         direction="column"
         flex="1"
         height="calc(100vh - 4.375rem)" // workaround to ensure Sidebar vertically fills container

--- a/src/pages/map/[view]/[geography].tsx
+++ b/src/pages/map/[view]/[geography].tsx
@@ -199,7 +199,7 @@ const MapPage = ({ initialRouteParams }: MapPageProps) => {
         }}
         maxWidth={{
           base: "none",
-          md: "403px",
+          sm: "403px",
         }}
         direction="column"
         flex="1"


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
1) Open EDDE
2) View sidebar

Per [Figma](https://www.figma.com/file/U7dgahwMaggEmMI1l5O1Z9/?node-id=2332:69938) the Map view sidebar should be fixed at 403px for both CommData and DRM.

#### Tasks/Bug Numbers
 - Fixes [AB#7923](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/7923)

Preview: https://9f464f--equity-tool.netlify.app/map/data/district