### PR TITLE
8003 Prevent redundant view toggling

### DIFF
--- a/src/components/Map/ViewToggle.tsx
+++ b/src/components/Map/ViewToggle.tsx
@@ -42,6 +42,7 @@ export const ViewToggle = ({
             }}
             onClick={onCommunityDataClick}
             isActive={view === "data"}
+            isDisabled={view === "data"}
             isFullWidth
             data-cy="communityDataBtn-mobile"
           >
@@ -60,6 +61,7 @@ export const ViewToggle = ({
             }}
             onClick={onDrmClick}
             isActive={view === "drm"}
+            isDisabled={view === "drm"}
             isFullWidth
             data-cy="drmBtn-mobile"
           >

--- a/src/pages/map/[view]/[geography].tsx
+++ b/src/pages/map/[view]/[geography].tsx
@@ -111,48 +111,52 @@ const MapPage = ({ initialRouteParams }: MapPageProps) => {
   const [lastBoroughGeoid, setLastBoroughGeoid] = useState<string | null>(null);
 
   const onDrmClick = () => {
-    setLastCommunityDataGeography(geography);
-    setLastCommunityDataGeoid(geoid);
+    if (view === "data") {
+      setLastCommunityDataGeography(geography);
+      setLastCommunityDataGeoid(geoid);
 
-    ReactGA.event({
-      category: "Toggle Tool",
-      action: "Click",
-      label: "Displacement Risk Map",
-    });
+      ReactGA.event({
+        category: "Toggle Tool",
+        action: "Click",
+        label: "Displacement Risk Map",
+      });
 
-    let drmPath = `/map/drm/${NTA}`;
+      let drmPath = `/map/drm/${NTA}`;
 
-    if (lastDrmGeoid) {
-      // TODO: revisit this if more query params will exist on Map view
-      drmPath += `?geoid=${lastDrmGeoid}`;
+      if (lastDrmGeoid) {
+        // TODO: revisit this if more query params will exist on Map view
+        drmPath += `?geoid=${lastDrmGeoid}`;
+      }
+
+      router.push(drmPath);
     }
-
-    router.push(drmPath);
   };
 
   const onCommunityDataClick = () => {
-    setLastDrmGeoid(geoid);
+    if (view === "drm") {
+      setLastDrmGeoid(geoid);
 
-    ReactGA.event({
-      category: "Toggle Tool",
-      action: "Click",
-      label: "Community Data",
-    });
+      ReactGA.event({
+        category: "Toggle Tool",
+        action: "Click",
+        label: "Community Data",
+      });
 
-    let communityDataPath = "/map/data";
+      let communityDataPath = "/map/data";
 
-    if (lastCommunityDataGeography) {
-      communityDataPath += `/${lastCommunityDataGeography}`;
+      if (lastCommunityDataGeography) {
+        communityDataPath += `/${lastCommunityDataGeography}`;
 
-      if (lastCommunityDataGeoid) {
-        // TODO: revisit this if more query params will exist on Map view
-        communityDataPath += `?geoid=${lastCommunityDataGeoid}`;
+        if (lastCommunityDataGeoid) {
+          // TODO: revisit this if more query params will exist on Map view
+          communityDataPath += `?geoid=${lastCommunityDataGeoid}`;
+        }
+      } else {
+        communityDataPath += `/${DISTRICT}`;
       }
-    } else {
-      communityDataPath += `/${DISTRICT}`;
-    }
 
-    router.push(communityDataPath);
+      router.push(communityDataPath);
+    }
   };
 
   const onCommunityDataGeographyChange = (targetGeography: Geography) => {

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -82,6 +82,7 @@ const theme = extendTheme({
         _active: {
           backgroundColor: "teal.50",
           color: "teal",
+          cursor: "default",
         },
         _disabled: {
           backgroundColor: "white",
@@ -104,6 +105,7 @@ const theme = extendTheme({
           borderRadius: 50,
           _active: {
             border: "1px solid teal",
+            cursor: "default",
           },
         },
         download: {


### PR DESCRIPTION
 - Fixes AB#8003

This PR prevents a user from re-clicking  the the toggle for the current view. It also adds guards to the toggle event handlers to make sure that any route processing -- and setting of previous selected geography -- only occurs if user is switching to the other view. 

