### PR TITLE
8012 Hide back button on citywide geography

### DIFF
--- a/src/components/SidebarContent/SidebarContent.tsx
+++ b/src/components/SidebarContent/SidebarContent.tsx
@@ -33,6 +33,9 @@ export const SidebarContent = () => {
               aria-label="Exit Community Data Selection"
               data-cy="exitCommunityDataSelection-desktop"
               onClick={clearSelection}
+              visibility={
+                geography === Geography.CITYWIDE ? "hidden" : "visible"
+              }
             >
               back
             </Button>


### PR DESCRIPTION
Fixes [AB#8012](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8012)
When a user has selected the citywide geography tab, there should not be a "back" button because the citywide geography is always selected by default under the citywide tab. Here, we keep the back button in the sidebar flow to prevent sidebar contents from jumping up and down between geography tabs. We only hide it by assigning `visibility: hidden` when citywide geography is selected. 