### PR TITLE
Update jest config to report coverage and add some unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,9 +40,11 @@
       "devDependencies": {
         "@babel/core": "^7.16.0",
         "@babel/preset-typescript": "^7.16.0",
+        "@testing-library/dom": "^8.13.0",
         "@testing-library/jest-dom": "^5.15.0",
         "@testing-library/react": "^12.1.2",
         "@testing-library/react-hooks": "^7.0.2",
+        "@testing-library/user-event": "^14.1.1",
         "@types/jest": "^27.0.2",
         "@types/node": "^14.6.0",
         "@types/react": "^17.0.3",
@@ -3604,9 +3606,10 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "8.11.1",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.13.0.tgz",
+      "integrity": "sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3817,6 +3820,19 @@
         "react-test-renderer": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.1.1.tgz",
+      "integrity": "sha512-XrjH/iEUqNl9lF2HX9YhPNV7Amntkcnpw0Bo1KkRzowNDcgSN9i0nm4Q8Oi5wupgdfPaJNMAWa61A+voD6Kmwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -31551,7 +31567,9 @@
       }
     },
     "@testing-library/dom": {
-      "version": "8.11.1",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.13.0.tgz",
+      "integrity": "sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
@@ -31679,6 +31697,13 @@
         "@types/react-test-renderer": ">=16.9.0",
         "react-error-boundary": "^3.1.0"
       }
+    },
+    "@testing-library/user-event": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.1.1.tgz",
+      "integrity": "sha512-XrjH/iEUqNl9lF2HX9YhPNV7Amntkcnpw0Bo1KkRzowNDcgSN9i0nm4Q8Oi5wupgdfPaJNMAWa61A+voD6Kmwg==",
+      "dev": true,
+      "requires": {}
     },
     "@tootallnate/once": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -60,9 +60,11 @@
   "devDependencies": {
     "@babel/core": "^7.16.0",
     "@babel/preset-typescript": "^7.16.0",
+    "@testing-library/dom": "^8.13.0",
     "@testing-library/jest-dom": "^5.15.0",
     "@testing-library/react": "^12.1.2",
     "@testing-library/react-hooks": "^7.0.2",
+    "@testing-library/user-event": "^14.1.1",
     "@types/jest": "^27.0.2",
     "@types/node": "^14.6.0",
     "@types/react": "^17.0.3",

--- a/src/components/DataPointCell/DataPointCell.spec.tsx
+++ b/src/components/DataPointCell/DataPointCell.spec.tsx
@@ -1,0 +1,79 @@
+import { ReactElement } from "react";
+import { render, screen, RenderOptions } from "@testing-library/react";
+import { Table, Tr, Tbody } from "@chakra-ui/react";
+import { DataPointCell } from "./DataPointCell";
+import { DataPoint } from "@schemas/dataPoint";
+
+interface TableWrapperProps {
+  children: ReactElement;
+}
+
+const TableWrapper = ({ children }: TableWrapperProps) => (
+  <Table>
+    <Tbody>
+      <Tr>{children}</Tr>
+    </Tbody>
+  </Table>
+);
+
+// Chakra Td elements must be rendered inside a Table by design. This simple wrapper around render()
+// keeps our tests DRY - see https://testing-library.com/docs/react-testing-library/setup/#custom-render
+// Might want to extract this to a common test utils folder so it can be used for other table components
+const renderInTable = (
+  ui: ReactElement,
+  options?: Omit<RenderOptions, "wrapper">
+) => render(ui, { wrapper: TableWrapper, ...options });
+
+describe("DataPointCell", () => {
+  it("shows a hyphen when value is null and variance is NONE", () => {
+    const dataPoint: DataPoint = {
+      value: null,
+      measure: "COUNT",
+      variance: "NONE",
+    };
+    renderInTable(<DataPointCell dataPoint={dataPoint} isReliable={true} />);
+    expect(screen.getByText("-")).toBeInTheDocument();
+  });
+
+  it("does not show hyphen when value is null and variance is not NONE", () => {
+    const dataPoint: DataPoint = {
+      value: null,
+      measure: "COUNT",
+      variance: "MOE",
+    };
+    renderInTable(<DataPointCell dataPoint={dataPoint} isReliable={true} />);
+    expect(screen.queryByText("-")).toBeNull();
+  });
+
+  it("renders the value with no decimal point if variance is not CV", () => {
+    const dataPoint: DataPoint = {
+      value: 1005.2,
+      measure: "COUNT",
+      variance: "MOE",
+    };
+    renderInTable(<DataPointCell dataPoint={dataPoint} isReliable={true} />);
+    expect(screen.getByText("1,005")).toBeInTheDocument();
+  });
+
+  it("renders the value with one digit after the decimal point if variance is CV", () => {
+    const dataPoint: DataPoint = {
+      value: 102.9,
+      measure: "COUNT",
+      variance: "CV",
+    };
+    renderInTable(<DataPointCell dataPoint={dataPoint} isReliable={true} />);
+    expect(screen.queryByText("102.9")).toBeInTheDocument();
+  });
+
+  it("renders the value as gray if isReliable is false", () => {
+    const dataPoint: DataPoint = {
+      value: 105,
+      measure: "COUNT",
+      variance: "NONE",
+    };
+    renderInTable(<DataPointCell dataPoint={dataPoint} isReliable={false} />);
+    expect(screen.getByText("105")).toHaveStyle(
+      "color: var(--chakra-colors-gray-400)"
+    );
+  });
+});

--- a/src/components/ExplorerSideNav/ExplorerSideNav.spec.tsx
+++ b/src/components/ExplorerSideNav/ExplorerSideNav.spec.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ExplorerSideNav } from "./ExplorerSideNav";
+import { Category } from "@constants/Category";
+import { Geography } from "@constants/geography";
+import { Subgroup } from "@constants/Subgroup";
+import { NYC } from "@constants/geoid";
+import { useDataExplorerState } from "@hooks/useDataExplorerState";
+import { getBoroughName } from "@helpers/getBoroughName";
+
+jest.mock("@hooks/useDataExplorerState");
+const mockedUseDataExplorerState = useDataExplorerState as jest.MockedFunction<
+  typeof useDataExplorerState
+>;
+
+jest.mock("@helpers/getBoroughName");
+const mockedGetBoroughName = getBoroughName as jest.MockedFunction<
+  typeof getBoroughName
+>;
+
+describe("ExplorerSideNav", () => {
+  describe("display selected geography information", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("should display the correct information for citywide", () => {
+      mockedUseDataExplorerState.mockReturnValueOnce({
+        geography: Geography.CITYWIDE,
+        geoid: NYC,
+        category: Category.DEMO,
+        subgroup: Subgroup.TOT,
+      });
+      render(<ExplorerSideNav />);
+      const textNodes = screen.getAllByText("Citywide");
+      expect(textNodes).toHaveLength(2);
+      expect(textNodes[0]).not.toBeVisible();
+    });
+
+    it("should display the correct information for borough", () => {
+      mockedUseDataExplorerState.mockReturnValueOnce({
+        geography: Geography.BOROUGH,
+        geoid: "3",
+        category: Category.DEMO,
+        subgroup: Subgroup.TOT,
+      });
+      mockedGetBoroughName.mockReturnValue("Brooklyn");
+      render(<ExplorerSideNav />);
+      const textNodes = screen.getAllByText("Brooklyn");
+      expect(mockedGetBoroughName).toBeCalledWith("3");
+      expect(textNodes).toHaveLength(2);
+      expect(textNodes[0]).not.toBeVisible();
+    });
+
+    it("should display the correct information for pumas", () => {
+      mockedUseDataExplorerState.mockReturnValueOnce({
+        geography: Geography.DISTRICT,
+        geoid: "4006",
+        category: Category.DEMO,
+        subgroup: Subgroup.TOT,
+      });
+      render(<ExplorerSideNav />);
+      const textNodes = screen.getAllByText("PUMA 4006");
+      expect(textNodes).toHaveLength(2);
+      expect(textNodes[0]).not.toBeVisible();
+    });
+  });
+
+  describe("toggle sidebar expanded state", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("shows the geography label under pin icon only after being collapsed", async () => {
+      mockedUseDataExplorerState.mockReturnValue({
+        geography: Geography.DISTRICT,
+        geoid: "4006",
+        category: Category.DEMO,
+        subgroup: Subgroup.TOT,
+      });
+      const user = userEvent.setup();
+      render(<ExplorerSideNav />);
+      expect(screen.getAllByText("PUMA 4006")[0]).not.toBeVisible();
+      await user.click(screen.getByLabelText("Show Categories"));
+      expect(screen.getAllByText("PUMA 4006")[0]).toBeVisible();
+    });
+  });
+});

--- a/src/components/GeographyInfo/GeographyInfo.tsx
+++ b/src/components/GeographyInfo/GeographyInfo.tsx
@@ -26,9 +26,10 @@ export const GeographyInfo = ({
   });
 
   useEffect(() => {
-    fetchNtaInfo(geoid, (ntaInfo: any) => {
-      setNtaInfo(ntaInfo);
-    });
+    geography === Geography.NTA &&
+      fetchNtaInfo(geoid, (ntaInfo: any) => {
+        setNtaInfo(ntaInfo);
+      });
   }, [geoid]);
 
   let primaryHeading = "";

--- a/src/helpers/parseDataExplorerSelection.spec.ts
+++ b/src/helpers/parseDataExplorerSelection.spec.ts
@@ -1,0 +1,53 @@
+import { Category } from "@constants/Category";
+import { Geography } from "@constants/geography";
+import { Subgroup } from "@constants/Subgroup";
+import { NYC } from "@constants/geoid";
+import { parseDataExplorerSelection } from "./parseDataExplorerSelection";
+
+describe("parseDataExplorerSelection", () => {
+  it("returns default values when query properties are undefined", () => {
+    const result = parseDataExplorerSelection({});
+    expect(result.geography).toEqual(Geography.CITYWIDE);
+    expect(result.geoid).toEqual(NYC);
+    expect(result.category).toEqual(Category.DEMO);
+    expect(result.subgroup).toEqual(Subgroup.TOT);
+  });
+
+  it("returns default values when query properties are arrays", () => {
+    const result = parseDataExplorerSelection({
+      geography: [Geography.BOROUGH],
+      geoid: ["BK0101"],
+      category: [Category.ECON],
+      subgroup: [Subgroup.HSP],
+    });
+    expect(result.geography).toEqual(Geography.CITYWIDE);
+    expect(result.geoid).toEqual(NYC);
+    expect(result.category).toEqual(Category.DEMO);
+    expect(result.subgroup).toEqual(Subgroup.TOT);
+  });
+
+  it("returns default values when query properties are arbitrary strings", () => {
+    const result = parseDataExplorerSelection({
+      geography: "foo",
+      geoid: "bar",
+      category: "biz",
+      subgroup: "baz",
+    });
+    expect(result.geography).toEqual(Geography.CITYWIDE);
+    expect(result.category).toEqual(Category.DEMO);
+    expect(result.subgroup).toEqual(Subgroup.TOT);
+  });
+
+  it("returns correct values when given valid query object", () => {
+    const result = parseDataExplorerSelection({
+      geography: Geography.DISTRICT,
+      geoid: "BK0101",
+      category: Category.ECON,
+      subgroup: Subgroup.ANH,
+    });
+    expect(result.geography).toEqual(Geography.DISTRICT);
+    expect(result.geoid).toEqual("BK0101");
+    expect(result.category).toEqual(Category.ECON);
+    expect(result.subgroup).toEqual(Subgroup.ANH);
+  });
+});

--- a/src/hooks/useDataExplorerState/useDataExplorerState.spec.ts
+++ b/src/hooks/useDataExplorerState/useDataExplorerState.spec.ts
@@ -1,0 +1,39 @@
+import { useRouter } from "next/router";
+import { useDataExplorerState } from "./useDataExplorerState";
+import { parseDataExplorerSelection } from "@helpers/parseDataExplorerSelection";
+
+jest.mock("next/router", () => ({
+  __esModule: true,
+  useRouter: jest.fn(() => ({
+    query: {
+      geography: "foo",
+      geoid: "bar",
+      category: "biz",
+      subgroup: "baz",
+    },
+  })),
+}));
+
+jest.mock("@helpers/parseDataExplorerSelection", () => ({
+  __esModule: true,
+  parseDataExplorerSelection: jest.fn(() => {
+    return;
+  }),
+}));
+
+describe("useDataExplorerState", () => {
+  it("calls useRouter", () => {
+    useDataExplorerState();
+    expect(useRouter).toHaveBeenCalled();
+  });
+
+  it("calls parseDataExplorerSelection with the values in the router query object", () => {
+    useDataExplorerState();
+    expect(parseDataExplorerSelection).toHaveBeenCalledWith({
+      geography: "foo",
+      geoid: "bar",
+      category: "biz",
+      subgroup: "baz",
+    });
+  });
+});

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -3,6 +3,8 @@ module.exports = {
   testEnvironment: "jsdom",
   setupFilesAfterEnv: ["<rootDir>/test/jest.setup.js"],
   testMatch: ["**/?(*.)+(spec|test).[tj]s?(x)"],
+  collectCoverage: true,
+  collectCoverageFrom: ["src/**/*.{js,jsx,ts,tsx}"],
   moduleNameMapper: {
     "^@components/(.*)$": "<rootDir>/src/components/$1",
     "^@data/(.*)$": "<rootDir>/src/data/$1",


### PR DESCRIPTION
### Summary
This PR updates the jest config to report coverage for the unit tests. Once we get up to an acceptable coverage score, we should add a coverage threshold guard on future PRs. I also added tests for a handful of files that I worked on. I'll have more PRs like this as I find time to pay down our unit test tech debt but wanted to put a lid on this for now so that other can point out if I'm doing anything silly in these tests before I go too far :). 

Note that this PR also includes changes found in this PR - https://github.com/NYCPlanning/equity-tool/pull/159 - mainly deleting some placeholder and boilerplate files, so we'll want to merge that PR first.

**There is one small change in this PR to actual application code** - I made a small change to GeographyInfo so that it only attempts to get NTA info if the selected Geography is `NTA`. This was originally made to avoid having to do some unnecessary mocking my tests but I think it's a good change on it's own and saves us executing more code than is necessary.