### PR TITLE
8005 reset params if geoid=nyc to prevent errors in the DRM

### DIFF
--- a/src/pages/map/[view]/[geography].tsx
+++ b/src/pages/map/[view]/[geography].tsx
@@ -124,7 +124,11 @@ const MapPage = ({ initialRouteParams }: MapPageProps) => {
 
     if (lastDrmGeoid) {
       // TODO: revisit this if more query params will exist on Map view
-      drmPath += `?geoid=${lastDrmGeoid}`;
+
+      // reset the params if geoid=nyc
+      !lastDrmGeoid.includes("nyc")
+        ? (drmPath += `?geoid=${lastDrmGeoid}`)
+        : (drmPath += "");
     }
 
     router.push(drmPath);


### PR DESCRIPTION
### Summary
<!---
Try to keep this more non-technical, and provide a wide angle, simple explanation of the problem and solution.
Navigating on EDDE
1) open EDDE
   url is `http://localhost:3000/map/data/district`
2) Select Citywide
   url is `http://localhost:3000/map/data/citywide?geoid=nyc`
3) click "Community Data"
   url is `http://localhost:3000/map/data/district
4) select Displacement Risk Map
   url is ` http://localhost:3000/map/drm/nta?geoid=nyc`
However the DRM does not support `geoid=nyc` so an error is displayed in the sidebar content.
   - What is the fix?
       - If the `geoid=nyc` , we need to reset the url not to include it.

##### error state
![error](https://user-images.githubusercontent.com/11340947/174400267-c3a043fb-b4ee-416b-9f5a-516b17257467.png)

##### the fix is in
https://user-images.githubusercontent.com/11340947/174400371-aa1560b6-6e1f-4ada-bc30-e96db16b4a56.mov


#### Tasks/Bug Numbers
 - Fixes AB#8005

### Technical Explanation
in the `/src/pages/map/[view]/[geography].tsx`, line 128, we need to check if the `lastDrmGeoid` includes `nyc`, and if so, reset the params to an empty string.
  