### PR TITLE
8003/8005 prevent 404 navigation error states

### DIFF
--- a/src/components/Map/ViewToggle.tsx
+++ b/src/components/Map/ViewToggle.tsx
@@ -42,6 +42,7 @@ export const ViewToggle = ({
             }}
             onClick={onCommunityDataClick}
             isActive={view === "data"}
+            isDisabled={view === "data"}
             isFullWidth
             data-cy="communityDataBtn-mobile"
           >
@@ -60,6 +61,7 @@ export const ViewToggle = ({
             }}
             onClick={onDrmClick}
             isActive={view === "drm"}
+            isDisabled={view === "drm"}
             isFullWidth
             data-cy="drmBtn-mobile"
           >
@@ -81,6 +83,7 @@ export const ViewToggle = ({
       >
         <Button
           onClick={onCommunityDataClick}
+          isDisabled={view === "data"}
           isActive={view === "data"}
           variant="toggle"
           data-cy="communityDataBtn-desktop"
@@ -90,6 +93,7 @@ export const ViewToggle = ({
         <Button
           onClick={onDrmClick}
           isActive={view === "drm"}
+          isDisabled={view === "drm"}
           variant="toggle"
           data-cy="drmBtn-desktop"
         >

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -82,6 +82,8 @@ const theme = extendTheme({
         _active: {
           backgroundColor: "teal.50",
           color: "teal",
+          cursor: "default",
+          opacity: "revert",
         },
         _disabled: {
           backgroundColor: "white",
@@ -104,6 +106,7 @@ const theme = extendTheme({
           borderRadius: 50,
           _active: {
             border: "1px solid teal",
+            cursor: "default",
           },
         },
         download: {


### PR DESCRIPTION
### Summary
Two 404 errors were surfacing with the following navigational clicks:
1) Navigate to the EDDE:
#### error state # 1
2) Select Displacement Risk Map
3) Click Displacement Risk Map again
4) Select Community Data
#### error state # 2
 2) Select Citywide
3) click "Community Data"
4) select Displacement Risk Map

After navigating through to each step 4, a 404 error resulted separately for both sets of steps.

Disabling the buttons for **COMMUNITY DAT**A and **DISPLACEMENT RISK MAP** when said buttons have already been selected and active prevents the navigation errors from occurring.
#### Tasks/Bug Numbers
 - Fixes AB#8003
 - Fixes AB#8005


### Technical Explanation
Prevents error states resulting in 404 errors with redundant toggling between community data and displacement risk map.
Adding the `isDisabled` attribute to the navigation buttons when the  routers`view` is equal to the current view (either `data` or `drm`) prevents additional onClick events in the `src/pages/map/[view]/[geography].tsx`'s `onDrmClick` (line 13) and `onCommunityDataClick` (line 133) functions.

