### PR TITLE
Adjust map initial view

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -23,8 +23,8 @@ export const Map = ({ layers, parent }: MapProps) => {
 
   const INITIAL_VIEW_STATE = {
     longitude: -74.0008,
-    latitude: 40.6838,
-    zoom: 10.8,
+    latitude: 40.7018,
+    zoom: 9.7,
     pitch: 0,
     bearing: 0,
   };


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
<!---
Try to keep this more non-technical, and provide a wide angle, simple explanation of the problem and solution.
   - What was wrong?
   - What is the fix?
   - Why?
     - What is the purpose?
     - How is it better?
   - Screenshots of the affected areas in the frontend are really nice!
-->
Resizes default map view to display all 5 boroughs
<img width="1440" alt="Screen Shot 2022-06-29 at 10 45 30 AM" src="https://user-images.githubusercontent.com/43344288/176466240-5429a3a1-950d-42a9-b2cf-80fba15aadc5.png">


#### Tasks/Bug Numbers
 - Fixes AB[#9114](https://dev.azure.com/NYCPlanning/ITD/_sprints/taskboard/Open%20Source%20Engineering/ITD/2022/Q3/Sprint%20N?workitem=9114)
<!---
Provide a link to a ticket, if applicable
-->

### Technical Explanation
<!---
  a. In technical terms, what was wrong, what is the fix, and why does it make things better? 
  b. If you can point to a specific line or file exhibiting the original problem, that would be great!
  c. Provide entrypoint of new solution, if different than (b).
  d. Provide overview of any new architecture.
       - How are components stringed together?
       - What is the new hierarchy? 
       - Any new components?
  e. Provide links and explanations for any new technical concepts, APIs and terms.
      Especially if you had to do some research yourself.
   List any ad-hoc, miscellaneous updates included
-->
Minor adjustments to Map component's [initial view state's](https://github.com/NYCPlanning/equity-tool/blob/5be1e55f86f515dc2a989e8f547395d88f5d750d/src/components/Map/Map.tsx#L24-L30) latitude and zoom parameters