### PR TITLE
Adjust map initial view on mobile

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -9,6 +9,7 @@ import baseMap from "@data/basemap.json";
 
 import { Box } from "@chakra-ui/react";
 import { useMapSubrouteInfo } from "@hooks/useMapSubrouteInfo";
+import { useWindowWidth } from "@react-hook/window-size";
 
 setDefaultCredentials({
   apiVersion: API_VERSIONS.V2,
@@ -21,13 +22,23 @@ type MapProps = Pick<DeckGLProps, "layers" | "parent">;
 export const Map = ({ layers, parent }: MapProps) => {
   const { view } = useMapSubrouteInfo();
 
-  const INITIAL_VIEW_STATE = {
-    longitude: -74.0008,
-    latitude: 40.7018,
-    zoom: 9.7,
-    pitch: 0,
-    bearing: 0,
-  };
+  const isMobile = useWindowWidth() < 768;
+
+  const INITIAL_VIEW_STATE = !isMobile
+    ? {
+        longitude: -74.0008,
+        latitude: 40.7018,
+        zoom: 9.7,
+        pitch: 0,
+        bearing: 0,
+      }
+    : {
+        longitude: -73.99,
+        latitude: 40.55,
+        zoom: 8.8,
+        pitch: 0,
+        bearing: 0,
+      };
 
   // MapContext is necessary for navigation controls to work.
   // Likely because it holds the view state, and keeps Deck and


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
<!---
Try to keep this more non-technical, and provide a wide angle, simple explanation of the problem and solution.
   - What was wrong?
   - What is the fix?
   - Why?
     - What is the purpose?
     - How is it better?
   - Screenshots of the affected areas in the frontend are really nice!
-->
Resizes default map view to display all 5 boroughs _on mobile devices_
<img width="339" alt="Screen Shot 2022-06-29 at 3 33 06 PM" src="https://user-images.githubusercontent.com/43344288/176520783-00df41b6-d1e2-4a34-9692-337bfc76e495.png">



#### Tasks/Bug Numbers
 - Addresses comment from design on AB[#9114](https://dev.azure.com/NYCPlanning/ITD/_sprints/taskboard/Open%20Source%20Engineering/ITD/2022/Q3/Sprint%20N?workitem=9114)
<!---
Provide a link to a ticket, if applicable
-->

### Technical Explanation
<!---
  a. In technical terms, what was wrong, what is the fix, and why does it make things better? 
  b. If you can point to a specific line or file exhibiting the original problem, that would be great!
  c. Provide entrypoint of new solution, if different than (b).
  d. Provide overview of any new architecture.
       - How are components stringed together?
       - What is the new hierarchy? 
       - Any new components?
  e. Provide links and explanations for any new technical concepts, APIs and terms.
      Especially if you had to do some research yourself.
   List any ad-hoc, miscellaneous updates included
-->
Checks for device size using the `useWindowWidth()` hook, then conditionally sets the map's `INITIAL_VIEW_STATE`