### PR TITLE
Task/7823 change and coding update

### DIFF
--- a/src/components/DataPointCell/DataPointCell.spec.tsx
+++ b/src/components/DataPointCell/DataPointCell.spec.tsx
@@ -30,9 +30,38 @@ describe("DataPointCell", () => {
       value: null,
       measure: "COUNT",
       variance: "NONE",
+      isReliable: undefined,
+      scale: undefined,
+      coding: undefined,
     };
-    renderInTable(<DataPointCell dataPoint={dataPoint} isReliable={true} />);
+    renderInTable(<DataPointCell dataPoint={dataPoint} />);
     expect(screen.getByText("-")).toBeInTheDocument();
+  });
+
+  it("shows a plus sign after value when value is not null, coding is TOP, and variance is NONE", () => {
+    const dataPoint: DataPoint = {
+      value: 1500,
+      measure: "COUNT",
+      variance: "NONE",
+      isReliable: false,
+      scale: undefined,
+      coding: "TOP",
+    };
+    renderInTable(<DataPointCell dataPoint={dataPoint} />);
+    expect(screen.getByText("1,500+")).toBeInTheDocument();
+  });
+
+  it("shows a minus sign after value when value is not null, coding is BOTTOM, and variance is NONE", () => {
+    const dataPoint: DataPoint = {
+      value: 1500,
+      measure: "COUNT",
+      variance: "NONE",
+      isReliable: false,
+      scale: undefined,
+      coding: "BOTTOM",
+    };
+    renderInTable(<DataPointCell dataPoint={dataPoint} />);
+    expect(screen.getByText("1,500-")).toBeInTheDocument();
   });
 
   it("does not show hyphen when value is null and variance is not NONE", () => {
@@ -40,8 +69,11 @@ describe("DataPointCell", () => {
       value: null,
       measure: "COUNT",
       variance: "MOE",
+      isReliable: undefined,
+      scale: undefined,
+      coding: undefined,
     };
-    renderInTable(<DataPointCell dataPoint={dataPoint} isReliable={true} />);
+    renderInTable(<DataPointCell dataPoint={dataPoint} />);
     expect(screen.queryByText("-")).toBeNull();
   });
 
@@ -50,8 +82,11 @@ describe("DataPointCell", () => {
       value: 1005.2,
       measure: "COUNT",
       variance: "MOE",
+      isReliable: undefined,
+      scale: undefined,
+      coding: undefined,
     };
-    renderInTable(<DataPointCell dataPoint={dataPoint} isReliable={true} />);
+    renderInTable(<DataPointCell dataPoint={dataPoint} />);
     expect(screen.getByText("1,005")).toBeInTheDocument();
   });
 
@@ -60,8 +95,11 @@ describe("DataPointCell", () => {
       value: 102.9,
       measure: "COUNT",
       variance: "CV",
+      isReliable: undefined,
+      scale: undefined,
+      coding: undefined,
     };
-    renderInTable(<DataPointCell dataPoint={dataPoint} isReliable={true} />);
+    renderInTable(<DataPointCell dataPoint={dataPoint} />);
     expect(screen.queryByText("102.9")).toBeInTheDocument();
   });
 
@@ -70,8 +108,11 @@ describe("DataPointCell", () => {
       value: 105,
       measure: "COUNT",
       variance: "NONE",
+      isReliable: false,
+      scale: undefined,
+      coding: undefined,
     };
-    renderInTable(<DataPointCell dataPoint={dataPoint} isReliable={false} />);
+    renderInTable(<DataPointCell dataPoint={dataPoint} />);
     expect(screen.getByText("105")).toHaveStyle(
       "color: var(--chakra-colors-gray-400)"
     );

--- a/src/components/DataPointCell/DataPointCell.spec.tsx
+++ b/src/components/DataPointCell/DataPointCell.spec.tsx
@@ -51,6 +51,19 @@ describe("DataPointCell", () => {
     expect(screen.getByText("1,500+")).toBeInTheDocument();
   });
 
+  it("shows number with correct digits after decimal when given scale value", () => {
+    const dataPoint: DataPoint = {
+      value: 1500,
+      measure: "COUNT",
+      variance: "NONE",
+      isReliable: false,
+      scale: 1,
+      coding: undefined,
+    };
+    renderInTable(<DataPointCell dataPoint={dataPoint} />);
+    expect(screen.getByText("1,500.0")).toBeInTheDocument();
+  });
+
   it("shows a minus sign after value when value is not null, coding is BOTTOM, and variance is NONE", () => {
     const dataPoint: DataPoint = {
       value: 1500,

--- a/src/components/DataPointCell/DataPointCell.tsx
+++ b/src/components/DataPointCell/DataPointCell.tsx
@@ -3,24 +3,32 @@ import { DataPoint } from "@schemas/dataPoint";
 
 export interface DataPointCellProps {
   dataPoint: DataPoint;
-  isReliable: boolean;
 }
 
-export const DataPointCell = ({
-  dataPoint,
-  isReliable,
-}: DataPointCellProps) => {
-  const { value, variance } = dataPoint;
+export const DataPointCell = ({ dataPoint }: DataPointCellProps) => {
+  const { value, variance, isReliable = true } = dataPoint;
 
   let formattedValue = "";
   if (value === null) {
     formattedValue = variance === "NONE" ? "-" : "";
   } else {
-    const roundTo = variance === "CV" ? 1 : 0;
+    let scale = 0;
+    if (variance === "CV") {
+      scale = 1;
+    } else if (typeof dataPoint.scale !== "undefined") {
+      scale = dataPoint.scale;
+    }
+    // const roundTo = variance === "CV" ? 1 : 0;
     formattedValue = value.toLocaleString(undefined, {
-      maximumFractionDigits: roundTo,
-      minimumFractionDigits: roundTo,
+      maximumFractionDigits: scale,
+      minimumFractionDigits: scale,
     });
+
+    if (dataPoint?.coding === "TOP") {
+      formattedValue = `${formattedValue}+`;
+    } else if (dataPoint?.coding === "BOTTOM") {
+      formattedValue = `${formattedValue}-`;
+    }
   }
   return (
     <Td

--- a/src/components/DataPointRow/DataPointRow.tsx
+++ b/src/components/DataPointRow/DataPointRow.tsx
@@ -56,8 +56,6 @@ export const DataPointRow = ({
     );
   }
 
-  const cv = cells.find((dataPoint) => dataPoint.variance === "CV");
-  const isReliable = cv && (cv.value === null || cv.value >= 20) ? false : true;
   return (
     <Tr
       {...props}
@@ -96,18 +94,13 @@ export const DataPointRow = ({
           return dataPoint.variance === "NONE";
         })
         .map((dataPoint, j) =>
-          dataPoint.measure === "PERCENT" ? (
+          ["PERCENT", "PERCENTAGE_POINT"].includes(dataPoint.measure) ? (
             <PercentDataPointCell
               key={`data-point-cell-${j}`}
               dataPoint={dataPoint}
-              isReliable={isReliable}
             />
           ) : (
-            <DataPointCell
-              key={`data-point-cell-${j}`}
-              dataPoint={dataPoint}
-              isReliable={isReliable}
-            />
+            <DataPointCell key={`data-point-cell-${j}`} dataPoint={dataPoint} />
           )
         )}
     </Tr>

--- a/src/components/PercentDataPointCell.tsx/PercentDataPointCell.tsx
+++ b/src/components/PercentDataPointCell.tsx/PercentDataPointCell.tsx
@@ -3,23 +3,23 @@ import { DataPoint } from "@schemas/dataPoint";
 
 export interface PercentDataPointCellProps {
   dataPoint: DataPoint;
-  isReliable: boolean;
 }
 
 export const PercentDataPointCell = ({
   dataPoint,
-  isReliable,
 }: PercentDataPointCellProps) => {
-  const { value } = dataPoint;
+  const { value, measure, isReliable = true } = dataPoint;
   let formattedValue = "";
   if (value === null) {
     formattedValue = "";
   } else {
-    formattedValue =
-      value.toLocaleString(undefined, {
-        maximumFractionDigits: 1,
-        minimumFractionDigits: 1,
-      }) + "%";
+    formattedValue = value.toLocaleString(undefined, {
+      maximumFractionDigits: 1,
+      minimumFractionDigits: 1,
+    });
+    if (measure === "PERCENT") {
+      formattedValue = `${formattedValue}%`;
+    }
   }
   return (
     <Td

--- a/src/components/VintageTable/VintageTable.tsx
+++ b/src/components/VintageTable/VintageTable.tsx
@@ -13,7 +13,7 @@ export interface VintageTableProps {
 
 const VintageTable = forwardRef<HTMLTableElement, VintageTableProps>(
   ({ vintage, rowHeights, shouldShowReliability, isSurvey }, ref) => {
-    const { rows, headers, label } = vintage;
+    const { rows, headers, label, isChange } = vintage;
     const [isOpen, setIsOpen] = useState(true);
 
     const { addSetIsOpen } = useTablesIsOpen();
@@ -74,11 +74,21 @@ const VintageTable = forwardRef<HTMLTableElement, VintageTableProps>(
               px={"1rem"}
               minWidth={{
                 base: "calc(100vw - 26px)",
-                md: isSurvey && shouldShowReliability ? "30.5rem" : "15.375rem",
+                md:
+                  isSurvey && shouldShowReliability
+                    ? "30.5rem"
+                    : isChange
+                    ? "29.25rem"
+                    : "15.375rem",
               }}
               maxWidth={{
                 base: "calc(100vw - 26px)",
-                md: isSurvey && shouldShowReliability ? "30.5rem" : "15.375rem",
+                md:
+                  isSurvey && shouldShowReliability
+                    ? "30.5rem"
+                    : isChange
+                    ? "29.25rem"
+                    : "15.375rem",
               }}
             >
               <Flex

--- a/src/schemas/dataPoint.ts
+++ b/src/schemas/dataPoint.ts
@@ -1,11 +1,14 @@
-import { object, string, number, InferType } from "yup";
+import { object, string, number, boolean, InferType } from "yup";
 
 export const dataPointSchema = object({
   value: number().nullable().defined(),
   measure: string()
-    .oneOf(["COUNT", "PERCENT", "RATE", "INDEX", "MEDIAN"])
+    .oneOf(["COUNT", "PERCENT", "RATE", "INDEX", "MEDIAN", "PERCENTAGE_POINT"])
     .required(),
   variance: string().oneOf(["NONE", "MOE", "CV"]).required(),
+  isReliable: boolean().optional(),
+  coding: string().oneOf(["TOP", "BOTTOM"]).optional(),
+  scale: number().optional(),
 });
 
 export type DataPoint = InferType<typeof dataPointSchema>;

--- a/src/schemas/vintage.ts
+++ b/src/schemas/vintage.ts
@@ -1,10 +1,11 @@
-import { object, string, array, number, InferType } from "yup";
+import { object, string, array, number, boolean, InferType } from "yup";
 import { rowSchema } from "@schemas/row";
 
 export const vintageSchema = object({
   label: string().required(),
   placeholder: string().optional(),
   rows: array().of(rowSchema).required(),
+  isChange: boolean().required(),
   headers: array()
     .of(
       array()


### PR DESCRIPTION
### Summary
This PR updates the table components to support three new properties:

* `isReliable` - previously this was derived on the client side, but now comes with the data. Note that this property can be undefined for values that have no CV, such as decennial census data. The UI will gray numbers only if this value _is defined and is `false`_
* `coding` - This conveys whether the value is top or bottom coded. Will be undefined for non-coded data, or `"TOP"` or `"BOTTOM"`
* `scale` - "scale" refers the mathematical term for the number of digits in a floating point number after the decimal point. The number `349.383` has a scale of 3, `25.2` has a scale of 1, etc. This is an optional property useful for data points with a `VARIANCE` of "NONE" that need to be displayed with an arbitrary number of numbers of the decimal, regardles of what's in the underlying data - some examples of this are median age, most "rates", and some "square mile" data points. Data points with `VARIANCE` OF "NONE" that have no "scale" value will display as whole integers (aka a scale of 0).

This PR also includes code to handle change-over-time data but, as of opening this PR, the ETL repo is still being updated to include that data, so it will not be displayed for the purposes of testing this PR.