### PR TITLE
8049 - Reorder housing security title alphabetically

### DIFF
--- a/src/components/CategoryMenu/CategoryMenu.tsx
+++ b/src/components/CategoryMenu/CategoryMenu.tsx
@@ -70,7 +70,7 @@ export const CategoryMenu = ({
         });
       }}
     >
-      Housing Security, Affordability and Quality
+      Housing Affordability, Quality, and Security
     </CategoryMenuLink>
     <CategoryMenuLink
       icon={<BuildingHouseIcon />}

--- a/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
@@ -95,7 +95,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
     [Category.DEMO]: "Demographic Conditions",
     [Category.ECON]: "Household Economic Security",
     [Category.HOPD]: "Housing Production",
-    [Category.HSAQ]: "Housing Security, Affordability, and Quality",
+    [Category.HSAQ]: "Housing Affordability, Quality, and Security",
     [Category.QLAO]: "Quality of Life and Access to Opportunity",
   };
 


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
<!---
Try to keep this more non-technical, and provide a wide angle, simple explanation of the problem and solution.
   - What was wrong?
   - What is the fix?
   - Why?
     - What is the purpose?
     - How is it better?
   - Screenshots of the affected areas in the frontend are really nice!
-->
Reorders the Housing Security category and section title in alphabetical order on the EDDE front-end.

Housing Security, Affordability, and Quality -> Housing Affordability, Quality, and Security

<img width="1440" alt="Screen Shot 2022-07-06 at 9 22 32 AM" src="https://user-images.githubusercontent.com/43344288/177561676-4b7d40a6-0973-44a9-9e3d-9aa68534a781.png">

#### Tasks/Bug Numbers
 - Fixes AB[#8049](https://dev.azure.com/NYCPlanning/ITD/_sprints/taskboard/Open%20Source%20Engineering/ITD/2022/Q3/Sprint%20N?workitem=8049)
<!---
Provide a link to a ticket, if applicable
-->

#### Note:
In the interest of consistency, we may want to also consider renaming the HSAQ category and JSON files to match the new section title. (ie. borough_1_hsaq.json -> borough_1_hasq.json)