### PR TITLE
9366 – Reset Community Data default boundary

### DIFF
--- a/src/pages/map/[view]/[geography].tsx
+++ b/src/pages/map/[view]/[geography].tsx
@@ -111,7 +111,7 @@ const MapPage = ({ initialRouteParams }: MapPageProps) => {
   const [lastBoroughGeoid, setLastBoroughGeoid] = useState<string | null>(null);
 
   const onDrmClick = () => {
-    setLastCommunityDataGeography(geography);
+    setLastCommunityDataGeography(null);
     setLastCommunityDataGeoid(geoid);
 
     ReactGA.event({


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
<!---
Try to keep this more non-technical, and provide a wide angle, simple explanation of the problem and solution.
   - What was wrong?
   - What is the fix?
   - Why?
     - What is the purpose?
     - How is it better?
   - Screenshots of the affected areas in the frontend are really nice!
-->
Clicking on a boundary (eg. Community District, Borough, Citywide) in the Community Data map, navigating to the DRM, and then navigating back would cause the Community Data map to default to that boundary.

By setting the `LastCommunityDataGeography` state to null when clicking into the DRM map, we can preserve the default view and intended behavior.

Video preview:
https://user-images.githubusercontent.com/43344288/177577349-7d8b6fb5-1f32-4e1e-b75a-ab06097703d3.mov

#### Tasks/Bug Numbers
 - Fixes AB[#9366](https://dev.azure.com/NYCPlanning/ITD/_sprints/taskboard/Open%20Source%20Engineering/ITD/2022/Q3/Sprint%20N?workitem=9366)