### PR TITLE
 9426 'Community Data' and 'DRM' are transparent when selected on mobile view

### DIFF
--- a/src/components/Map/ViewToggle.tsx
+++ b/src/components/Map/ViewToggle.tsx
@@ -31,7 +31,6 @@ export const ViewToggle = ({
         >
           <Button
             flex="1"
-            variant="toggle"
             backgroundColor="gray.50"
             height="100%"
             borderRadius=".5rem 0 0 0"
@@ -43,14 +42,15 @@ export const ViewToggle = ({
             onClick={onCommunityDataClick}
             isActive={view === "data"}
             isDisabled={view === "data"}
+            _hover={{ _disabled: { bg: "teal.50" } }}
             isFullWidth
             data-cy="communityDataBtn-mobile"
+            variant="mobileButton"
           >
             Community Data
           </Button>
           <Button
             flex="1"
-            variant="toggle"
             backgroundColor="gray.50"
             height="100%"
             borderRadius="0 .5rem 0 0"
@@ -62,8 +62,10 @@ export const ViewToggle = ({
             onClick={onDrmClick}
             isActive={view === "drm"}
             isDisabled={view === "drm"}
+            _hover={{ _disabled: { bg: "teal.50" } }}
             isFullWidth
             data-cy="drmBtn-mobile"
+            variant="mobileButton"
           >
             Displacement Risk Map
           </Button>

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -74,7 +74,6 @@ const theme = extendTheme({
       baseStyle: {
         backgroundColor: "white",
         color: "gray.600",
-
         _hover: {
           backgroundColor: "teal.50",
           color: "teal",
@@ -107,6 +106,7 @@ const theme = extendTheme({
           _active: {
             border: "1px solid teal",
             cursor: "default",
+            opacity: "1 !important",
           },
         },
         download: {
@@ -119,6 +119,15 @@ const theme = extendTheme({
           _disabled: {
             backgroundColor: "white",
             color: "teal",
+          },
+        },
+        mobileButton: {
+          opacity: "1 !important",
+          borderRadius: 50,
+          _active: {
+            border: "1px solid teal",
+            cursor: "default",
+            opacity: "1 !important",
           },
         },
       },


### PR DESCRIPTION
### Summary
A bug fix for a desktop navigation error was applied unnecessarily to the mobile experience causing unexpected styling in the mobile buttons..

#### Tasks/Bug Numbers
 - Fixes [AB#9426](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/9426)

#### BEFORE
![error](https://user-images.githubusercontent.com/11340947/177821760-3cbead32-9573-44c7-bfa9-5eab1d13347d.png)

#### AFTER
<img width="411" alt="Screen Shot 2022-07-07 at 12 10 55 PM" src="https://user-images.githubusercontent.com/11340947/177821795-c5b71690-e963-4431-99e7-26fcbd887824.png">


### Technical Explanation
removing the disabled attribute logic from the mobile buttons in `src/components/Map/ViewToggle.tsx`, lines 46 and 64
- the logic was originally put in to prevent navigation errors found on the desktop when click between comm data and DRM per [AB#8003](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/8003) and [AB#8005](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/8005). The same conditions do not apply to the mobile navigation experience
 -  additionally, the disable attribute was overriding the button styles (the transparency)

https://user-images.githubusercontent.com/11340947/178515395-3289e98a-aa76-4e8a-a504-aa9f510325bd.mov


