### PR TITLE
9622 - Remove mobile back button

### DIFF
--- a/cypress/integration/pages/map.view/geography.spec.ts
+++ b/cypress/integration/pages/map.view/geography.spec.ts
@@ -274,23 +274,6 @@ describe("Map catch-all page", () => {
         "Sunnyside & Woodside"
       );
     });
-
-    it("should clear selection when user hits 'back' button", () => {
-      cy.visit("/map/data/district?geoid=4108");
-
-      cy.get('[data-cy="mobileDrawer-communityData"]').should(
-        "contain",
-        "Forest Hills & Rego Park"
-      );
-
-      cy.get('[data-cy="mobileDrawer-welcome"]').should("not.exist");
-
-      cy.get('[data-cy="exitCommunityDataSelection-mobile"]').click();
-
-      cy.get('[data-cy="mobileDrawer-communityData"]').should("not.exist");
-
-      cy.get('[data-cy="mobileDrawer-welcome"]').should("exist");
-    });
   });
 });
 

--- a/src/components/Map/CommunityData/MobileDrawer.tsx
+++ b/src/components/Map/CommunityData/MobileDrawer.tsx
@@ -1,6 +1,4 @@
-import { Box, Button, Divider, Flex } from "@chakra-ui/react";
-import { ArrowBackIcon } from "@chakra-ui/icons";
-import { useClearSelection } from "@helpers/useClearSelection";
+import { Box, Divider, Flex } from "@chakra-ui/react";
 import { GeographyInfo } from "@components/GeographyInfo";
 
 import { useMapSubrouteInfo } from "@hooks/useMapSubrouteInfo";
@@ -10,8 +8,6 @@ import { NYC } from "@constants/geoid";
 
 export const CommunityDataMobileDrawer = () => {
   const { geoid, geography } = useMapSubrouteInfo();
-
-  const clearSelection = useClearSelection();
 
   return (
     <Box
@@ -31,29 +27,6 @@ export const CommunityDataMobileDrawer = () => {
     >
       <Flex direction="column" height="100%" position="relative">
         <Box
-          position="absolute"
-          width="100%"
-          top={0}
-          cursor="pointer"
-          zIndex="999"
-          align="left"
-          bg="rgba(0,0,0,0)"
-        >
-          <Button
-            padding="1.5rem 1rem"
-            variant="ghost"
-            bg="rgba(0,0,0,0)"
-            color="gray.500"
-            leftIcon={<ArrowBackIcon />}
-            aria-label="Exit Community Data Selection"
-            data-cy="exitCommunityDataSelection-mobile"
-            onClick={clearSelection}
-          >
-            back
-          </Button>
-        </Box>
-
-        <Box
           flex="auto"
           overflow="scroll"
           paddingTop="1rem"
@@ -63,7 +36,7 @@ export const CommunityDataMobileDrawer = () => {
             },
           }}
         >
-          <Box padding="2.5rem 1rem 1.5rem 1rem">
+          <Box padding="0.5rem 1rem 0.5rem 1rem">
             <GeographyInfo
               geoid={geography && geoid ? geoid : NYC}
               geography={geography}


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
<!---
Try to keep this more non-technical, and provide a wide angle, simple explanation of the problem and solution.
   - What was wrong?
   - What is the fix?
   - Why?
     - What is the purpose?
     - How is it better?
   - Screenshots of the affected areas in the frontend are really nice!
-->
Removes the Back button in Citywide tab on mobile views.

#### Tasks/Bug Numbers
 - Fixes AB[#9622](https://dev.azure.com/NYCPlanning/ITD/_sprints/taskboard/Open%20Source%20Engineering/ITD/2022/Q3/Sprint%20O?workitem=9622)

![Screen Shot 2022-07-19 at 11 22 14 AM](https://user-images.githubusercontent.com/43344288/179789071-ba95174d-e029-4918-842d-8d06bcb5c773.png)

