### PR TITLE
9752 Add RER files to the data download

### DIFF
--- a/src/components/DataDownloadModal/DataDownloadModal.tsx
+++ b/src/components/DataDownloadModal/DataDownloadModal.tsx
@@ -180,9 +180,14 @@ export const DataDownloadModal = ({
               <FormControl isRequired p="0rem">
                 <RadioGroup onChange={updateFiletype} value={filetype}>
                   <Stack direction="column">
-                    <Radio isDisabled={true} value="pdf">
-                      Community Profile (.pdf) (coming soon)
-                    </Radio>
+                    {geography === Geography.DISTRICT ? (
+                      <Radio value="pdf">Community Profile (.pdf)</Radio>
+                    ) : (
+                      <Radio isDisabled={true} value="pdf">
+                        Community Profile (.pdf) (only avaialable on district
+                        level)
+                      </Radio>
+                    )}
                     <Radio value="xls">Data set (.xls)</Radio>
                   </Stack>
                 </RadioGroup>


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
All three files zipped together for each PUMA, and downloaded when the user selects the PDF download on the Data Tables page for a PUMA. There will not be any changes made to downloads from the Data Tables page for Boro and Citywide, nor will there be changes to the download on the DRM.

<img width="479" alt="image" src="https://user-images.githubusercontent.com/61206501/180311365-fb652e95-7c6e-4b6f-8296-914a3b366628.png">
<img width="479" alt="image" src="https://user-images.githubusercontent.com/61206501/180311448-f4d6e3ca-9bbc-450c-9ca3-a35a2305717a.png">


#### Tasks/Bug Numbers
 - Completes [AB#9752](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/9752)


### Technical Explanation
PDFs are only available for districts, so added logic to check the geotype and serve up the appropriate text.

### Any other info you think would help a reviewer understand this PR?
