### PR TITLE
AB#10659 Category tooltips

### DIFF
--- a/src/components/CategoryMenu/CategoryMenu.tsx
+++ b/src/components/CategoryMenu/CategoryMenu.tsx
@@ -15,12 +15,14 @@ export interface CategoryMenuProps extends FlexProps {
   currentCategory?: Category;
   geography: Geography;
   geoid: string;
+  shouldDisableTooltips?: boolean;
 }
 
 export const CategoryMenu = ({
   geography,
   geoid,
   currentCategory,
+  shouldDisableTooltips = true,
   ...flexProps
 }: CategoryMenuProps) => (
   <Flex
@@ -34,6 +36,7 @@ export const CategoryMenu = ({
       icon={<FontAwesomeIcon icon={faUserGroup} width="1.5rem" />}
       href={`/data/${geography}/${geoid}/${Category.DEMO}/tot`}
       isActive={currentCategory === Category.DEMO}
+      isTooltipDisabled={shouldDisableTooltips}
       onClick={() => {
         ReactGA.event({
           category: "Select Community Data Profile",
@@ -48,6 +51,7 @@ export const CategoryMenu = ({
       icon={<FontAwesomeIcon icon={faUmbrella} width="1.5rem" />}
       href={`/data/${geography}/${geoid}/${Category.ECON}/tot`}
       isActive={currentCategory === Category.ECON}
+      isTooltipDisabled={shouldDisableTooltips}
       onClick={() => {
         ReactGA.event({
           category: "Select Community Data Profile",
@@ -62,6 +66,7 @@ export const CategoryMenu = ({
       icon={<FontAwesomeIcon icon={faHouseUser} width="1.5rem" />}
       href={`/data/${geography}/${geoid}/${Category.HSAQ}/tot`}
       isActive={currentCategory === Category.HSAQ}
+      isTooltipDisabled={shouldDisableTooltips}
       onClick={() => {
         ReactGA.event({
           category: "Select Community Data Profile",
@@ -76,6 +81,7 @@ export const CategoryMenu = ({
       icon={<BuildingHouseIcon />}
       href={`/data/${geography}/${geoid}/${Category.HOPD}/tot`}
       isActive={currentCategory === Category.HOPD}
+      isTooltipDisabled={shouldDisableTooltips}
       onClick={() => {
         ReactGA.event({
           category: "Select Community Data Profile",
@@ -90,6 +96,7 @@ export const CategoryMenu = ({
       icon={<MentalHealthIcon />}
       href={`/data/${geography}/${geoid}/${Category.QLAO}/tot`}
       isActive={currentCategory === Category.QLAO}
+      isTooltipDisabled={shouldDisableTooltips}
       onClick={() => {
         ReactGA.event({
           category: "Select Community Data Profile",

--- a/src/components/CategoryMenu/CategoryMenuLink.spec.tsx
+++ b/src/components/CategoryMenu/CategoryMenuLink.spec.tsx
@@ -1,0 +1,36 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CategoryMenuLink } from "./CategoryMenuLink";
+
+describe("CategoryMenuLink", () => {
+  it("should not show tooltips on hover by default", async () => {
+    const user = userEvent.setup();
+    render(
+      <CategoryMenuLink icon={<span>icon</span>} href={"/foo/bar"}>
+        demo conditions
+      </CategoryMenuLink>
+    );
+    const outerButton = screen.getByText("demo conditions");
+    const tooltipTrigger = within(outerButton).getByRole("button");
+    await user.hover(tooltipTrigger);
+    expect(screen.getAllByText("demo conditions")).toHaveLength(1);
+  });
+
+  it("should show tooltips on hover when isTooltipDisabled is false", async () => {
+    const user = userEvent.setup();
+    render(
+      <CategoryMenuLink
+        icon={<span>icon</span>}
+        href={"/foo/bar"}
+        isTooltipDisabled={false}
+      >
+        demo conditions
+      </CategoryMenuLink>
+    );
+
+    const outerButton = screen.getByText("demo conditions");
+    const tooltipTrigger = within(outerButton).getByRole("button");
+    await user.hover(tooltipTrigger);
+    expect(screen.getAllByText("demo conditions")).toHaveLength(2);
+  });
+});

--- a/src/components/CategoryMenu/CategoryMenuLink.tsx
+++ b/src/components/CategoryMenu/CategoryMenuLink.tsx
@@ -5,11 +5,13 @@ import {
   ButtonProps,
   Icon as ChakraIcon,
   Center,
+  Tooltip,
 } from "@chakra-ui/react";
 
 interface CategoryMenuLinkProps extends ButtonProps {
   href: string;
   icon: ReactNode;
+  isTooltipDisabled?: boolean;
 }
 
 export const CategoryMenuLink = ({
@@ -17,19 +19,28 @@ export const CategoryMenuLink = ({
   href,
   icon,
   isActive,
+  isTooltipDisabled = true,
   ...buttonProps
 }: CategoryMenuLinkProps): JSX.Element => {
   const Icon = () => (
-    <Center
-      boxSize={"2.25rem"}
-      borderRadius="50%"
-      background={"teal.600"}
-      color={"gray.200"}
-      my={"0.625rem"}
-      fontSize={"1.125rem"}
+    <Tooltip
+      label={children}
+      isDisabled={isTooltipDisabled}
+      hasArrow
+      placement="right"
     >
-      {icon}
-    </Center>
+      <Center
+        boxSize={"2.25rem"}
+        borderRadius="50%"
+        background={"teal.600"}
+        color={"gray.200"}
+        my={"0.625rem"}
+        fontSize={"1.125rem"}
+        role="button"
+      >
+        {icon}
+      </Center>
+    </Tooltip>
   );
 
   return (

--- a/src/components/ExplorerSideNav/ExplorerSideNav.tsx
+++ b/src/components/ExplorerSideNav/ExplorerSideNav.tsx
@@ -89,6 +89,7 @@ export const ExplorerSideNav = () => {
           geography={geography}
           geoid={geoid}
           currentCategory={category}
+          shouldDisableTooltips={isOpen}
           justify={"start"}
         />
       </Box>


### PR DESCRIPTION
### Summary
This PR adds some tooltips to `CategoryMenuLink` using Chakra's `<Tooltip>` component. I added props to this component as well as to `CategoryMenu` to allow them to be disabled in cases where we want to use CategoryMenu but never show tooltips (such as in `MobileDrawer` and `SidebarContent`.

#### Tasks/Bug Numbers
 - Implements [AB#10659](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/10659)
