### PR TITLE
Update netlify.toml to never use caching in builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "npm run build"
   publish = "out"
   environment = { NODE_ENV="staging", NETLIFY_NEXT_PLUGIN_SKIP = "true" }
-  ignore = "if [ $CACHED_COMMIT_REF == $COMMIT_REF ]; then (exit 1); else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ../..; fi;"
+  ignore = "false"
 
 [[redirects]]
   from = "/"


### PR DESCRIPTION
### Summary
This PR just changes a value in `netlify.toml` to hopefully resolve some issues I'm having where changes in the underlying EDDE data aren't getting incorporated when I manually re-run one of the build jobs, presumably because of some caching on Netlify's side.
