### PR TITLE
Task/10658 data page sticky header

### DIFF
--- a/src/components/DataDownloadModal/DataDownloadModal.tsx
+++ b/src/components/DataDownloadModal/DataDownloadModal.tsx
@@ -45,7 +45,7 @@ export const DataDownloadModal = ({
   };
 
   const baseUrl = "https://equity-tool-data.nyc3.digitaloceanspaces.com";
-  const pumaInfo = usePumaInfo(geoid);
+  const pumaInfo = usePumaInfo();
 
   const getUrl = () => {
     if (downloadType === "drm") {

--- a/src/components/GeographyInfo/GeographyInfo.tsx
+++ b/src/components/GeographyInfo/GeographyInfo.tsx
@@ -19,7 +19,7 @@ export const GeographyInfo = ({
 }: GeographyInfoProps) => {
   const { DISTRICT, BOROUGH, CITYWIDE, NTA } = Geography;
 
-  const pumaInfo = usePumaInfo(geoid);
+  const pumaInfo = usePumaInfo();
 
   const [ntaInfo, setNtaInfo] = useState({
     ntaname: "",

--- a/src/components/SubgroupMenu/SubgroupMenu.tsx
+++ b/src/components/SubgroupMenu/SubgroupMenu.tsx
@@ -1,0 +1,81 @@
+import { Flex, Button } from "@chakra-ui/react";
+import { Subgroup } from "@constants/Subgroup";
+import { useSubgroup } from "@hooks/useSubgroup";
+import { useGeography } from "@hooks/useGeography";
+import { useGeoid } from "@hooks/useGeoid";
+import { useCategory } from "@hooks/useCategory";
+import { Category } from "@constants/Category";
+
+export const SubgroupMenu = () => {
+  const subgroupLabels: Record<Subgroup, string> = {
+    [Subgroup.TOT]: "Total population",
+    [Subgroup.ANH]: "Asian Non-Hispanic",
+    [Subgroup.BNH]: "Black Non-Hispanic",
+    [Subgroup.HSP]: "Hispanic",
+    [Subgroup.WNH]: "White Non-Hispanic",
+  };
+
+  const currentSubgroup = useSubgroup();
+  const geoid = useGeoid();
+  const geography = useGeography();
+  const category = useCategory();
+
+  return (
+    <Flex
+      direction={"row"}
+      overflowX={"auto"}
+      whiteSpace={"nowrap"}
+      paddingLeft={{ base: "0.75rem", md: "1rem" }}
+    >
+      {Object.values(Subgroup).map((subgroup) => (
+        <Button
+          key={`subgroup-${subgroup}`}
+          bg="white"
+          borderRadius={"none"}
+          color="gray.600"
+          fontWeight="medium"
+          fontSize={"0.875rem"}
+          m={0}
+          px={"1rem"}
+          py={"0.625rem"}
+          justifyContent={"center"}
+          isDisabled={category === Category.HOPD && subgroup !== Subgroup.TOT}
+          aria-current={subgroup === currentSubgroup ? "page" : false}
+          _activeLink={{
+            boxShadow: "inset 0 -4px 0 0 #2C7A7B",
+            fontWeight: "bold",
+            color: "teal.600",
+            background: "white",
+          }}
+          _hover={{
+            boxShadow: "inset 0 -4px 0 0 #2C7A7B",
+            background: "gray.50",
+            fontWeight: "bold",
+            _disabled: {
+              background: "white",
+              fontWeight: "medium",
+              boxShadow: "unset",
+            },
+          }}
+          _focus={{
+            boxShadow: "inset 0 -4px 0 0 #2C7A7B",
+            background: "gray.50",
+            fontWeight: "bold",
+            _disabled: {
+              background: "white",
+              fontWeight: "medium",
+              boxShadow: "unset",
+            },
+          }}
+          as="a"
+          href={`/data/${geography}/${
+            geoid ? geoid : ""
+          }/${category}/${subgroup}`}
+          flex={"0 0 auto"}
+        >
+          {subgroupLabels[subgroup]}
+        </Button>
+      ))}
+    </Flex>
+  );
+};

--- a/src/components/SubgroupMenu/SubgroupMenu.tsx
+++ b/src/components/SubgroupMenu/SubgroupMenu.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from "next/router";
 import { Flex, Button } from "@chakra-ui/react";
 import { Subgroup } from "@constants/Subgroup";
 import { useSubgroup } from "@hooks/useSubgroup";
@@ -15,6 +16,7 @@ export const SubgroupMenu = () => {
     [Subgroup.WNH]: "White Non-Hispanic",
   };
 
+  const router = useRouter();
   const currentSubgroup = useSubgroup();
   const geoid = useGeoid();
   const geography = useGeography();
@@ -40,8 +42,8 @@ export const SubgroupMenu = () => {
           py={"0.625rem"}
           justifyContent={"center"}
           isDisabled={category === Category.HOPD && subgroup !== Subgroup.TOT}
-          aria-current={subgroup === currentSubgroup ? "page" : false}
-          _activeLink={{
+          isActive={subgroup === currentSubgroup}
+          _active={{
             boxShadow: "inset 0 -4px 0 0 #2C7A7B",
             fontWeight: "bold",
             color: "teal.600",
@@ -67,10 +69,11 @@ export const SubgroupMenu = () => {
               boxShadow: "unset",
             },
           }}
-          as="a"
-          href={`/data/${geography}/${
-            geoid ? geoid : ""
-          }/${category}/${subgroup}`}
+          onClick={() => {
+            router.push(
+              `/data/${geography}/${geoid ? geoid : ""}/${category}/${subgroup}`
+            );
+          }}
           flex={"0 0 auto"}
         >
           {subgroupLabels[subgroup]}

--- a/src/components/SubgroupMenu/index.ts
+++ b/src/components/SubgroupMenu/index.ts
@@ -1,0 +1,1 @@
+export * from "./SubgroupMenu";

--- a/src/constants/Subgroup.ts
+++ b/src/constants/Subgroup.ts
@@ -1,7 +1,7 @@
 export enum Subgroup {
   TOT = "tot",
-  WNH = "wnh",
-  BNH = "bnh",
   ANH = "anh",
+  BNH = "bnh",
   HSP = "hsp",
+  WNH = "wnh",
 }

--- a/src/hooks/useGeoidDescription/index.ts
+++ b/src/hooks/useGeoidDescription/index.ts
@@ -1,0 +1,1 @@
+export * from "./useGeoidDescription";

--- a/src/hooks/useGeoidDescription/useGeoidDescription.ts
+++ b/src/hooks/useGeoidDescription/useGeoidDescription.ts
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import { useGeography } from "@hooks/useGeography";
+import { useGeoid } from "@hooks/useGeoid/useGeoid";
+import { usePumaInfo } from "@hooks/usePumaInfo";
+import { Geography } from "@constants/geography";
+import { getBoroughName } from "@helpers/getBoroughName";
+import { fetchNtaInfo } from "@helpers/fetchNtaInfo";
+
+export interface GeoidDescription {
+  id: string;
+  label: string;
+}
+
+export const useGeoidDescription = (): GeoidDescription => {
+  const { DISTRICT, BOROUGH, CITYWIDE, NTA } = Geography;
+  const geography = useGeography();
+  const geoid = useGeoid();
+
+  const pumaInfo = usePumaInfo();
+
+  const [ntaInfo, setNtaInfo] = useState({
+    ntaname: "",
+    ntacode: "",
+  });
+
+  useEffect(() => {
+    geography === Geography.NTA &&
+      fetchNtaInfo(geoid, (ntaInfo: any) => {
+        setNtaInfo(ntaInfo);
+      });
+  }, [geoid]);
+
+  if (geoid === null) {
+    return {
+      id: "",
+      label: "",
+    };
+  }
+
+  switch (geography) {
+    case DISTRICT:
+      return {
+        id: `PUMA ${geoid}`,
+        label: pumaInfo?.neighborhoods ? pumaInfo.neighborhoods : "",
+      };
+    case BOROUGH:
+      return {
+        id: "",
+        label: getBoroughName(geoid),
+      };
+    case CITYWIDE:
+      return {
+        id: "",
+        label: "Citywide",
+      };
+    case NTA:
+      // primaryHeading = `${ntaInfo?.ntaname}`;
+      return {
+        id: `NTA: ${geoid}`,
+        label: ntaInfo.ntaname,
+      };
+    default:
+      return {
+        id: "",
+        label: "",
+      };
+  }
+};

--- a/src/hooks/usePumaInfo/usePumaInfo.ts
+++ b/src/hooks/usePumaInfo/usePumaInfo.ts
@@ -1,10 +1,12 @@
 import pumas from "@data/pumas.json";
+import { useGeoid } from "@hooks/useGeoid";
 import { hasOwnProperty } from "@helpers/hasOwnProperty";
 
 export type pumaInfo = typeof pumas["3701"];
 
-export const usePumaInfo = (pumaId: string | null): pumaInfo | null => {
-  if (!pumaId || !hasOwnProperty(pumas, pumaId)) return null;
+export const usePumaInfo = (): pumaInfo | null => {
+  const geoid = useGeoid();
+  if (!geoid || !hasOwnProperty(pumas, geoid)) return null;
 
-  return pumas[pumaId];
+  return pumas[geoid];
 };

--- a/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
@@ -245,7 +245,7 @@ const DataPage = ({ indicators, geoid }: DataPageProps) => {
               fontWeight={700}
               textTransform={"capitalize"}
               fontSize={"1.5625rem"}
-              color={"gray.600"}
+              color={"gray.700"}
               data-cy="geoInfoPrimaryHeading"
             >
               {categoryLabels[category]}:{" "}

--- a/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
@@ -241,7 +241,10 @@ const DataPage = ({ indicators, geoid }: DataPageProps) => {
               fontSize={"1.5625rem"}
               data-cy="geoInfoPrimaryHeading"
             >
-              {categoryLabels[category]}: {geoidDescription.label}
+              {categoryLabels[category]}:{" "}
+              <Text as="span" fontWeight={400}>
+                {geoidDescription.label}
+              </Text>
             </Heading>
             {category === Category.HOPD && (
               <Text

--- a/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
@@ -167,45 +167,36 @@ const DataPage = ({ indicators, geoid }: DataPageProps) => {
       gridGap={{ base: "1.5rem", md: "0rem" }}
     >
       <ExplorerSideNav geoid={geoid} />
-      <Box flexGrow={1} overflowX={{ base: "visible", md: "hidden" }}>
-        <Box
-          paddingTop={"1rem"}
-          borderBottomColor={"gray.300"}
-          borderBottomWidth={"1px"}
-          position={{ base: "relative", md: "sticky" }}
-          top={{ base: "initial", md: "0" }}
+      <Box flexGrow={1} overflowX={{ base: "initial", md: "hidden" }}>
+        <Flex
+          direction={"row"}
+          justifyContent={"space-between"}
+          alignItems={"center"}
+          paddingTop={"0.75rem"}
+          marginRight={"1rem"}
+          paddingLeft={{ base: "0.75rem", md: "1rem" }}
           background={"white"}
+          position={{ base: "relative", md: "sticky" }}
+          top={{ base: "unset", md: "0" }}
           zIndex={"200"}
         >
-          <Flex
-            direction={"row"}
-            justifyContent={"space-between"}
-            alignItems={"center"}
-            marginBottom={"0.75rem"}
-            marginRight={"1rem"}
-            paddingLeft={{ base: "0.75rem", md: "1rem" }}
-            position={{ base: "sticky", md: "sticky" }}
-            top={{ base: "0", md: "0" }}
-            background={"white"}
-            zIndex={"300"}
+          <Box
+            as="a"
+            href={`/map/data/${geography}?geoid=${geoid}`}
+            color={"gray.600"}
+            fontSize={"0.875rem"}
           >
-            <Box
-              as="a"
-              href={`/map/data/${geography}?geoid=${geoid}`}
-              color={"gray.600"}
-              fontSize={"0.875rem"}
-            >
-              <ArrowBackIcon w={"1.5rem"} h={"1.5rem"} color={"gray.600"} />
-              back to map
-            </Box>
-            <DataDownloadModal
-              downloadType={"data"}
-              geoid={geoid}
-              geography={geography}
-            />
-          </Flex>
+            <ArrowBackIcon w={"1.5rem"} h={"1.5rem"} color={"gray.600"} />
+            back to map
+          </Box>
+          <DataDownloadModal
+            downloadType={"data"}
+            geoid={geoid}
+            geography={geography}
+          />
+        </Flex>
+        <Box display={{ base: "block", md: "none" }} marginTop={"0.75rem"}>
           <Text
-            display={{ base: "block", md: "none" }}
             width={"100%"}
             color={"gray.600"}
             textAlign="center"
@@ -226,98 +217,97 @@ const DataPage = ({ indicators, geoid }: DataPageProps) => {
             geography={geography}
             geoid={geoid}
             currentCategory={category}
-            display={{ base: "flex", md: "none" }}
             justify={"start"}
             marginTop={"0.5rem"}
             marginBottom={"1rem"}
             paddingLeft={{ base: "0.75rem", md: "1rem" }}
           />
+        </Box>
+        <Box
+          paddingTop={"1rem"}
+          position={"sticky"}
+          top={{ base: "0px", md: "52px" }} // Match height of "back to map" <Flex>
+          background={"white"}
+          zIndex={"200"}
+        >
           <Box
-            // position={{ base: "sticky", md: "relative" }}
-            // top={{ base: "0", md: "initial" }}
-            // background={"white"}
-            // position={{ base: "sticky", md: "sticky" }}
-            // top={{ base: "0", md: "0" }}
-            // background={"white"}
-            // zIndex={"220"}
-            id="foo"
+            paddingBottom={{ base: "1rem", md: "1.5rem" }}
+            paddingLeft={{ base: "0.75rem", md: "1rem" }}
           >
-            <Box
-              paddingBottom="1.5rem"
-              paddingLeft={{ base: "0.75rem", md: "1rem" }}
+            <Heading
+              as="h1"
+              fontWeight={700}
+              textTransform={"capitalize"}
+              fontSize={"1.5625rem"}
+              data-cy="geoInfoPrimaryHeading"
             >
-              <Heading
-                as="h1"
-                fontWeight={700}
-                textTransform={"capitalize"}
-                fontSize={"1.5625rem"}
-                data-cy="geoInfoPrimaryHeading"
+              {categoryLabels[category]}: {geoidDescription.label}
+            </Heading>
+            {category === Category.HOPD && (
+              <Text
+                fontStyle={"italic"}
+                color={"gray.400"}
+                marginTop="0.25rem"
+                fontSize={"0.8125rem"}
+                lineHeight={"2"}
               >
-                {categoryLabels[category]}: {geoidDescription.label}
-              </Heading>
-              {category === Category.HOPD && (
-                <Text
-                  fontStyle={"italic"}
-                  color={"gray.400"}
-                  marginTop="0.25rem"
-                  fontSize={"0.8125rem"}
-                  lineHeight={"2"}
-                >
-                  *Racial breakdowns are not available for Housing Production.
-                </Text>
-              )}
-            </Box>
-            <Flex
-              direction={"row"}
-              justify={"space-between"}
-              flexWrap={"wrap-reverse"}
-            >
-              <SubgroupMenu />
-              {category !== Category.HOPD && (
-                <FormControl
-                  width={"auto"}
-                  display={"flex"}
-                  alignItems="center"
-                  marginRight={"1rem"}
-                  paddingLeft={{ base: "0.75rem", md: "1rem" }}
-                >
-                  <Switch
-                    colorScheme="gray"
-                    isChecked={shouldShowReliability}
-                    onChange={() => {
-                      toggleReliability();
-                    }}
-                    id="show-reliability"
-                  />
-                  <FormLabel
-                    htmlFor="show-reliability"
-                    mb="0"
-                    marginX={"0.375rem"}
-                    color={"gray.700"}
-                    whiteSpace={"nowrap"}
-                  >
-                    Show reliability data
-                  </FormLabel>
-                  <Tooltip
-                    hasArrow
-                    placement="top-end"
-                    label={
-                      <Text>
-                        Note: Data shown in gray have poor statistical
-                        reliability. Learn more about our{" "}
-                        <Link href="/methods" color={"#fff"}>
-                          data sources
-                        </Link>
-                        .
-                      </Text>
-                    }
-                  >
-                    <InfoIcon color="gray.400" />
-                  </Tooltip>
-                </FormControl>
-              )}
-            </Flex>
+                *Racial breakdowns are not available for Housing Production.
+              </Text>
+            )}
           </Box>
+          <Flex
+            direction={"row"}
+            justify={"space-between"}
+            flexWrap={"wrap-reverse"}
+            gap={{ base: "1rem", md: "1.5rem" }}
+            borderBottomColor={"gray.300"}
+            borderBottomWidth={"1px"}
+          >
+            <SubgroupMenu />
+            {category !== Category.HOPD && (
+              <FormControl
+                width={"auto"}
+                display={"flex"}
+                alignItems="center"
+                marginRight={"1rem"}
+                paddingLeft={{ base: "0.75rem", md: "1rem" }}
+              >
+                <Switch
+                  colorScheme="gray"
+                  isChecked={shouldShowReliability}
+                  onChange={() => {
+                    toggleReliability();
+                  }}
+                  id="show-reliability"
+                />
+                <FormLabel
+                  htmlFor="show-reliability"
+                  mb="0"
+                  marginX={"0.375rem"}
+                  color={"gray.700"}
+                  whiteSpace={"nowrap"}
+                >
+                  Show reliability data
+                </FormLabel>
+                <Tooltip
+                  hasArrow
+                  placement="top-end"
+                  label={
+                    <Text>
+                      Note: Data shown in gray have poor statistical
+                      reliability. Learn more about our{" "}
+                      <Link href="/methods" color={"#fff"}>
+                        data sources
+                      </Link>
+                      .
+                    </Text>
+                  }
+                >
+                  <InfoIcon color="gray.400" />
+                </Tooltip>
+              </FormControl>
+            )}
+          </Flex>
         </Box>
         <HStack
           width="100%"

--- a/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import { GetStaticProps, GetStaticPaths } from "next";
 import {
   Box,
@@ -11,7 +11,12 @@ import {
   Heading,
   Link,
   HStack,
-  Tooltip,
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverArrow,
+  PopoverBody,
+  IconButton,
 } from "@chakra-ui/react";
 import { ArrowBackIcon, InfoIcon } from "@chakra-ui/icons";
 import { Indicator } from "@components/Indicator";
@@ -158,6 +163,7 @@ const DataPage = ({ indicators, geoid }: DataPageProps) => {
   };
 
   const geoidDescription = useGeoidDescription();
+  const initialFocusRef = useRef(null);
 
   return (
     <Flex
@@ -232,13 +238,14 @@ const DataPage = ({ indicators, geoid }: DataPageProps) => {
         >
           <Box
             paddingBottom={{ base: "1rem", md: "1.5rem" }}
-            paddingLeft={{ base: "0.75rem", md: "1rem" }}
+            paddingX={{ base: "0.75rem", md: "1rem" }}
           >
             <Heading
               as="h1"
               fontWeight={700}
               textTransform={"capitalize"}
               fontSize={"1.5625rem"}
+              color={"gray.600"}
               data-cy="geoInfoPrimaryHeading"
             >
               {categoryLabels[category]}:{" "}
@@ -249,7 +256,7 @@ const DataPage = ({ indicators, geoid }: DataPageProps) => {
             {category === Category.HOPD && (
               <Text
                 fontStyle={"italic"}
-                color={"gray.400"}
+                color={"gray.600"}
                 marginTop="0.25rem"
                 fontSize={"0.8125rem"}
                 lineHeight={"2"}
@@ -292,22 +299,33 @@ const DataPage = ({ indicators, geoid }: DataPageProps) => {
                 >
                   Show reliability data
                 </FormLabel>
-                <Tooltip
-                  hasArrow
-                  placement="top-end"
-                  label={
-                    <Text>
+                <Popover placement="top-end" initialFocusRef={initialFocusRef}>
+                  <PopoverTrigger>
+                    <IconButton
+                      icon={<InfoIcon color="gray.400" />}
+                      aria-label="Show data reliability warning"
+                      background={"transparent"}
+                      minWidth={"auto"}
+                      height={"auto"}
+                      _hover={{ background: "transparent" }}
+                    />
+                  </PopoverTrigger>
+                  <PopoverContent backgroundColor={"#000"} width={"320px"}>
+                    <PopoverArrow backgroundColor={"#000"} />
+                    <PopoverBody width={"320px"} color={"#fff"}>
                       Note: Data shown in gray have poor statistical
                       reliability. Learn more about our{" "}
-                      <Link href="/methods" color={"#fff"}>
+                      <Link
+                        ref={initialFocusRef}
+                        href="/methods"
+                        color={"#fff"}
+                      >
                         data sources
                       </Link>
                       .
-                    </Text>
-                  }
-                >
-                  <InfoIcon color="gray.400" />
-                </Tooltip>
+                    </PopoverBody>
+                  </PopoverContent>
+                </Popover>
               </FormControl>
             )}
           </Flex>

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -84,10 +84,6 @@ const theme = extendTheme({
           cursor: "default",
           opacity: "revert",
         },
-        _disabled: {
-          backgroundColor: "white",
-          color: "teal",
-        },
       },
       variants: {
         leftCap: {


### PR DESCRIPTION
### Summary
This PR adds the redesign of the "header" portion of the data tables page.
* Header is made "sticky" when user scrolls, with different portions of it being sticky depending on users screen size
* Moves data reliability message into a popover
* Adds new tab-like buttons for switching between subgroups, instead of the existing dropdown select
* Various other style and positioning tweaks

I also added a new `useGeoidDescription` hook to consolidate some of the logic for getting the human-readable "labels" for geoids into one place.
