### PR TITLE
10994 Added back to top button to mobile data view

### DIFF
--- a/src/components/BackToTop/BackToTop.tsx
+++ b/src/components/BackToTop/BackToTop.tsx
@@ -2,11 +2,26 @@ import { ArrowUpIcon } from "@chakra-ui/icons";
 import { Box, Button, Link } from "@chakra-ui/react";
 
 export const BackToTop = () => {
+  const scrollToTop = () => {
+    document.getElementById("back-to-top")!.scrollTop = 0;
+  };
+
   return (
     <>
-      <Link href="#data-top">
-        <Box position="fixed" bottom="16px" right="16px" zIndex={3}>
-          <Button width="1rem" border="1px" borderColor="#CBD5E0">
+      <Link onClick={scrollToTop}>
+        <Box
+          position="fixed"
+          bottom="16px"
+          right="16px"
+          zIndex={3}
+          onClick={scrollToTop}
+        >
+          <Button
+            width="1rem"
+            border="1px"
+            borderColor="#CBD5E0"
+            onClick={scrollToTop}
+          >
             <ArrowUpIcon />
           </Button>
         </Box>

--- a/src/components/BackToTop/BackToTop.tsx
+++ b/src/components/BackToTop/BackToTop.tsx
@@ -1,0 +1,16 @@
+import { ArrowUpIcon } from "@chakra-ui/icons";
+import { Box, Button, Link } from "@chakra-ui/react";
+
+export const BackToTop = () => {
+  return (
+    <>
+      <Link href="#data-top">
+        <Box position="fixed" bottom="16px" right="16px" zIndex={3}>
+          <Button width="1rem" border="1px" borderColor="#CBD5E0">
+            <ArrowUpIcon />
+          </Button>
+        </Box>
+      </Link>
+    </>
+  );
+};

--- a/src/components/BackToTop/index.ts
+++ b/src/components/BackToTop/index.ts
@@ -1,0 +1,1 @@
+export * from "./BackToTop";

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -25,6 +25,7 @@ function MyApp({ Component, pageProps }: AppProps) {
         <Box
           height="calc(100vh - 4.375rem)"
           overflow={isMapRoute ? "hidden" : "auto"}
+          id="back-to-top"
         >
           <Flex direction="row" height="100%" position="relative">
             <Component {...pageProps} />

--- a/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
@@ -24,6 +24,7 @@ import { CategoryMenu } from "@components/CategoryMenu";
 import { DataDownloadModal } from "@components/DataDownloadModal";
 import { ExplorerSideNav } from "@components/ExplorerSideNav";
 import { SubgroupMenu } from "@components/SubgroupMenu";
+import { BackToTop } from "@components/BackToTop";
 import { useGeography } from "@hooks/useGeography";
 import { useCategory } from "@hooks/useCategory";
 import { useGeoidDescription } from "@hooks/useGeoidDescription";
@@ -39,6 +40,7 @@ import ReactGA from "react-ga4";
 import { hasOwnProperty } from "@helpers/hasOwnProperty";
 import { TablesIsOpenProvider } from "@contexts/TablesIsOpenContext";
 import { Geography } from "@constants/geography";
+import { useWindowWidth } from "@react-hook/window-size";
 
 export interface DataPageProps {
   indicators: IndicatorRecord[];
@@ -150,6 +152,7 @@ const DataPage = ({ indicators, geoid }: DataPageProps) => {
   const geography = useGeography();
   const category = useCategory();
   const pumaInfo = usePumaInfo();
+  const isMobile = useWindowWidth() < 768;
 
   const tablesSetIsOpens: React.Dispatch<boolean>[] = [];
 
@@ -171,9 +174,13 @@ const DataPage = ({ indicators, geoid }: DataPageProps) => {
       height={"full"}
       direction={{ base: "column", md: "row" }}
       gridGap={{ base: "1.5rem", md: "0rem" }}
+      id="data-top"
     >
       <ExplorerSideNav geoid={geoid} />
+
       <Box flexGrow={1} overflowX={{ base: "initial", md: "hidden" }}>
+        {isMobile && <BackToTop />}
+
         <Flex
           direction={"row"}
           justifyContent={"space-between"}

--- a/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
@@ -174,7 +174,6 @@ const DataPage = ({ indicators, geoid }: DataPageProps) => {
       height={"full"}
       direction={{ base: "column", md: "row" }}
       gridGap={{ base: "1.5rem", md: "0rem" }}
-      id="data-top"
     >
       <ExplorerSideNav geoid={geoid} />
 


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
<!---
Try to keep this more non-technical, and provide a wide angle, simple explanation of the problem and solution.
   - What was wrong?
   - What is the fix?
   - Why?
     - What is the purpose?
     - How is it better?
   - Screenshots of the affected areas in the frontend are really nice!
-->
As a user, I want to be able to quickly return to the top of the data tables with a single button when I am scrolling through tables in mobile 

[https://www.figma.com/file/8ExFFiN7KDe6vzoQchnOJC/EDDE-1.1?node-id=173%3A18853](https://www.figma.com/file/8ExFFiN7KDe6vzoQchnOJC/EDDE-1.1?node-id=173:18853)

![Screen Shot 2022-10-18 at 15 15 43](https://user-images.githubusercontent.com/61206501/196523269-ed165bae-8b5a-4256-af83-81a123e7430d.png)

#### Tasks/Bug Numbers
 - Implements [AB#10994](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/10994)


### Technical Explanation
<!---
  a. In technical terms, what was wrong, what is the fix, and why does it make things better? 
  b. If you can point to a specific line or file exhibiting the original problem, that would be great!
  c. Provide entrypoint of new solution, if different than (b).
  d. Provide overview of any new architecture.
       - How are components stringed together?
       - What is the new hierarchy? 
       - Any new components?
  e. Provide links and explanations for any new technical concepts, APIs and terms.
      Especially if you had to do some research yourself.
   List any ad-hoc, miscellaneous updates included
-->

### Any other info you think would help a reviewer understand this PR?
