### PR TITLE
11174 PUMA and NTA labels illegible at first appearance

### DIFF
--- a/src/data/dcp_nta_2010_centers.json
+++ b/src/data/dcp_nta_2010_centers.json
@@ -93,34 +93,6 @@
     },
     {
       "coordinates": [
-        -74.128351,
-        40.545779
-      ],
-      "label": "park-cemetery-etc\nStaten Island"
-    },
-    {
-      "coordinates": [
-        -73.9598,
-        40.787943
-      ],
-      "label": "park-cemetery-etc\nManhattan"
-    },
-    {
-      "coordinates": [
-        -73.832763,
-        40.690302
-      ],
-      "label": "park-cemetery-etc\nQueens"
-    },
-    {
-      "coordinates": [
-        -73.919588,
-        40.623095
-      ],
-      "label": "park-cemetery-etc\nBrooklyn"
-    },
-    {
-      "coordinates": [
         -73.876474,
         40.571485
       ],
@@ -349,13 +321,6 @@
         40.638971
       ],
       "label": "West New Brighton-New Brighton-St. George"
-    },
-    {
-      "coordinates": [
-        -73.847998,
-        40.872461
-      ],
-      "label": "park-cemetery-etc-\nBronx"
     },
     {
       "coordinates": [

--- a/src/helpers/LabeledCartoLayer.ts
+++ b/src/helpers/LabeledCartoLayer.ts
@@ -107,9 +107,6 @@ export class LabeledCartoLayer extends CompositeLayer<any, any> {
     if (layer.id.slice(-14) === "_pumatextlayer") {
       return 10.5 < viewport.zoom && viewport.zoom < 13;
     } else if (layer.id.slice(-13) === "_ntatextlayer") {
-      if (this.props.passedId === "nta") {
-        return 11 < viewport.zoom && viewport.zoom < 15;
-      }
       return 12 < viewport.zoom && viewport.zoom < 15;
     } else if (layer.id.slice(-14) === "_borotextlayer") {
       return viewport.zoom < 11;

--- a/src/helpers/LabeledCartoLayer.ts
+++ b/src/helpers/LabeledCartoLayer.ts
@@ -42,9 +42,29 @@ export class LabeledCartoLayer extends CompositeLayer<any, any> {
         }
       ),
       new TextLayer({
-        visible: this.props.visible,
+        visible: this.props.visible && this.props.passedId == NTA,
         data: ntaLabels.features,
-        id: `${this.props.passedId}_ntatextlayer`,
+        id: `${this.props.passedId}_ntatextlayer_drm`,
+        uniqueIdProperty: "id",
+        getPosition: (x: any) => x.coordinates,
+        getText: (x: any) => x.label.toUpperCase(),
+        getSize: 12,
+        billboard: true,
+        getColor: [74, 85, 104, 200],
+        fontFamily: "Helvetica Neue",
+        fontSettings: {
+          sdf: true,
+        },
+        outlineWidth: 1,
+        outlineColor: [255, 255, 255, 255],
+        maxWidth: 600,
+        sizeUnits: "pixels",
+        fontWeight: 700,
+      }),
+      new TextLayer({
+        visible: this.props.visible && this.props.passedId !== NTA,
+        data: ntaLabels.features,
+        id: `${this.props.passedId}_ntatextlayer_cd`,
         uniqueIdProperty: "id",
         getPosition: (x: any) => x.coordinates,
         getText: (x: any) => x.label.toUpperCase(),
@@ -59,7 +79,7 @@ export class LabeledCartoLayer extends CompositeLayer<any, any> {
         outlineColor: [255, 255, 255, 255],
         maxWidth: 800,
         sizeUnits: "meters",
-        fontWeight: 700,
+        // fontWeight: 700,
       }),
       new TextLayer({
         visible: this.props.visible && this.props.passedId !== NTA,
@@ -106,7 +126,9 @@ export class LabeledCartoLayer extends CompositeLayer<any, any> {
   filterSubLayer({ layer, viewport }: { layer: any; viewport: any }) {
     if (layer.id.slice(-14) === "_pumatextlayer") {
       return 10.5 < viewport.zoom && viewport.zoom < 13;
-    } else if (layer.id.slice(-13) === "_ntatextlayer") {
+    } else if (layer.id.slice(-17) === "_ntatextlayer_drm") {
+      return 12 < viewport.zoom && viewport.zoom < 15;
+    } else if (layer.id.slice(-16) === "_ntatextlayer_cd") {
       return 12 < viewport.zoom && viewport.zoom < 15;
     } else if (layer.id.slice(-14) === "_borotextlayer") {
       return viewport.zoom < 11;

--- a/src/helpers/LabeledCartoLayer.ts
+++ b/src/helpers/LabeledCartoLayer.ts
@@ -59,6 +59,7 @@ export class LabeledCartoLayer extends CompositeLayer<any, any> {
         outlineColor: [255, 255, 255, 255],
         maxWidth: 800,
         sizeUnits: "meters",
+        fontWeight: 700,
       }),
       new TextLayer({
         visible: this.props.visible && this.props.passedId !== NTA,

--- a/src/helpers/LabeledCartoLayer.ts
+++ b/src/helpers/LabeledCartoLayer.ts
@@ -48,7 +48,7 @@ export class LabeledCartoLayer extends CompositeLayer<any, any> {
         uniqueIdProperty: "id",
         getPosition: (x: any) => x.coordinates,
         getText: (x: any) => x.label.toUpperCase(),
-        getSize: 12,
+        getSize: 125,
         billboard: true,
         getColor: [74, 85, 104, 200],
         fontFamily: "Helvetica Neue",
@@ -57,8 +57,8 @@ export class LabeledCartoLayer extends CompositeLayer<any, any> {
         },
         outlineWidth: 1,
         outlineColor: [255, 255, 255, 255],
-        maxWidth: 600,
-        sizeUnits: "pixels",
+        maxWidth: 800,
+        sizeUnits: "meters",
         fontWeight: 700,
       }),
       new TextLayer({
@@ -79,7 +79,6 @@ export class LabeledCartoLayer extends CompositeLayer<any, any> {
         outlineColor: [255, 255, 255, 255],
         maxWidth: 800,
         sizeUnits: "meters",
-        // fontWeight: 700,
       }),
       new TextLayer({
         visible: this.props.visible && this.props.passedId !== NTA,
@@ -127,7 +126,7 @@ export class LabeledCartoLayer extends CompositeLayer<any, any> {
     if (layer.id.slice(-14) === "_pumatextlayer") {
       return 10.5 < viewport.zoom && viewport.zoom < 13;
     } else if (layer.id.slice(-17) === "_ntatextlayer_drm") {
-      return 12 < viewport.zoom && viewport.zoom < 15;
+      return 11 < viewport.zoom && viewport.zoom < 15;
     } else if (layer.id.slice(-16) === "_ntatextlayer_cd") {
       return 12 < viewport.zoom && viewport.zoom < 15;
     } else if (layer.id.slice(-14) === "_borotextlayer") {


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
- Makes NTA labels bolded on DRM view
- Removes the 5 "Park-Cemetery-Etc" labels

#### Tasks/Bug Numbers
 - Fixes [AB#11174](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/11174)


### Technical Explanation
<!---
  a. In technical terms, what was wrong, what is the fix, and why does it make things better? 
  b. If you can point to a specific line or file exhibiting the original problem, that would be great!
  c. Provide entrypoint of new solution, if different than (b).
  d. Provide overview of any new architecture.
       - How are components stringed together?
       - What is the new hierarchy? 
       - Any new components?
  e. Provide links and explanations for any new technical concepts, APIs and terms.
      Especially if you had to do some research yourself.
   List any ad-hoc, miscellaneous updates included
-->

### Any other info you think would help a reviewer understand this PR?
