### PR TITLE
11271 Back to top button alignment

### DIFF
--- a/src/components/BackToTop/BackToTop.tsx
+++ b/src/components/BackToTop/BackToTop.tsx
@@ -11,8 +11,8 @@ export const BackToTop = () => {
       <Link onClick={scrollToTop}>
         <Box
           position="fixed"
-          bottom="12px"
-          right="12px"
+          bottom="14px"
+          right="14px"
           zIndex={3}
           onClick={scrollToTop}
         >


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
[2:05 PM] Natasha Toal (DCP)

One small thing - with the back to top button, it seems like it is 12px from the right side, which is the same margin for our tables, but I think because of the styling of the tables it seems misaligned visually. Can we shift it a few pixels over until it looks aligned?
![image](https://user-images.githubusercontent.com/61206501/200048813-e5824e4b-3788-482f-a1fb-3b159a62d9a2.png)


#### Tasks/Bug Numbers
 - Fixes [AB#11271](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/11271)

### Technical Explanation
Moved it to 14px from the edge