### PR TITLE
AD#10908 Add support for new alphanumeric table ids

### DIFF
--- a/src/components/Indicator/Indicator.tsx
+++ b/src/components/Indicator/Indicator.tsx
@@ -1,4 +1,4 @@
-import { Heading, Box } from "@chakra-ui/react";
+import { Heading, Box, Flex } from "@chakra-ui/react";
 import { IndicatorRecord } from "@schemas/indicatorRecord";
 import { VintageList } from "@components/VintageList";
 
@@ -12,17 +12,33 @@ export const Indicator = ({
   shouldShowReliability,
 }: IndicatorProps) => {
   return (
-    <Box marginBottom="1.5rem">
-      <Heading
-        color={"gray.700"}
-        as="h3"
-        fontSize={"1.25rem"}
-        fontWeight={"700"}
-        marginBottom={{ base: "0.75rem", md: "1rem" }}
-        textTransform={"capitalize"}
-      >
-        {indicator.title}
-      </Heading>
+    <Box marginBottom={{ base: "1.5rem", lg: "2.5rem" }}>
+      <Flex direction={"column"}>
+        <Heading
+          color={"gray.700"}
+          as="h3"
+          fontSize={"1.25rem"}
+          fontWeight={"700"}
+          marginBottom={{ base: "0.75rem", md: "1rem" }}
+          textTransform={"capitalize"}
+          order={"2"}
+        >
+          {indicator.title}
+        </Heading>
+        {indicator.id !== null && (
+          <Heading
+            color={"gray.600"}
+            as="h4"
+            fontSize={"0.8125rem"}
+            fontWeight={"400"}
+            marginBottom={"0.25rem"}
+            lineHeight={"1.6"}
+            order={"1"}
+          >
+            Table {indicator.id}
+          </Heading>
+        )}
+      </Flex>
       <VintageList
         vintages={indicator.vintages}
         shouldShowReliability={shouldShowReliability}

--- a/src/schemas/indicatorRecord.ts
+++ b/src/schemas/indicatorRecord.ts
@@ -3,6 +3,7 @@ import { vintageSchema } from "@schemas/vintage";
 
 export const indicatorRecordSchema = object({
   title: string().required(),
+  id: string().nullable(),
   isSurvey: boolean().required(),
   vintages: array().of(vintageSchema).required(),
 });


### PR DESCRIPTION
### Summary
This PR adds support for a new "id" field on `indicatorRecord`s which show the alphanumeric table ids. It is nullable because some tables do not have one.
