### PR TITLE
Bug/12305 data table header heights

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ npm i
 This command should install all necessary dependencies and set up Husky to run on all commits
 
 2. Create `.env.local` and set the required environment variables.
+   - Local development credentials are available within the NYC planning password vault under "EDDE Credentials"
 
 
 ### Running locally

--- a/src/components/VintageList/VintageList.tsx
+++ b/src/components/VintageList/VintageList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, RefObject } from "react";
 import { Flex } from "@chakra-ui/react";
 import { Vintage } from "@schemas/vintage";
 import { VintageTable } from "@components/VintageTable";
@@ -10,6 +10,17 @@ export interface VintageListProps {
   shouldShowReliability: boolean;
   isSurvey: boolean;
 }
+
+const getClientHeights =
+  (elements: string) => (ref: RefObject<HTMLTableElement>) => {
+    const heights: number[] = [];
+    ref.current
+      ?.querySelectorAll(elements)
+      .forEach((node) => heights.push(node.clientHeight));
+    return heights;
+  };
+const getHeaderClientHeights = getClientHeights("thead tr");
+const getBodyClientHeights = getClientHeights("tbody tr");
 
 export const VintageList = ({
   vintages,
@@ -28,23 +39,15 @@ export const VintageList = ({
   const category = useCategory();
   const subgroup = useSubgroup();
 
-  // Update row heights whenever category or subgroup changes
+  // Update row header heights whenever category or subgroup changes, or reliability is toggled
   useEffect(() => {
-    const heights: number[] = [];
-    ref.current?.querySelectorAll("tbody tr").forEach((node) => {
-      heights.push(node.clientHeight);
-    });
-    setRowBodyHeights(heights);
-  }, [category, subgroup]);
-
-  // TODO: look into generalizing grabbing the heights of the elements
-  useEffect(() => {
-    const heights: number[] = [];
-    ref.current?.querySelectorAll("thead tr").forEach((node) => {
-      heights.push(node.clientHeight);
-    });
-    setRowHeaderHeights(heights);
+    setRowHeaderHeights(getHeaderClientHeights(ref));
   }, [category, subgroup, shouldShowReliability]);
+
+  // Update row body heights whenever category or subgroup changes
+  useEffect(() => {
+    setRowBodyHeights(getBodyClientHeights(ref));
+  }, [category, subgroup]);
 
   return (
     <Flex

--- a/src/components/VintageList/VintageList.tsx
+++ b/src/components/VintageList/VintageList.tsx
@@ -16,14 +16,13 @@ export const VintageList = ({
   shouldShowReliability,
   isSurvey,
 }: VintageListProps) => {
-  // TODO: create headerHeights state
-  // TODO: refactor to body heights
-  const [rowHeights, setRowHeights] = useState<number[]>([]);
+  const [rowHeaderHeights, setRowHeaderHeights] = useState<number[]>([]);
+  const [rowBodyHeights, setRowBodyHeights] = useState<number[]>([]);
 
   // This ref is passed to the first VintageTable for the indicator
   // When multiple VintageTables are stacked horizontally on desktop, only the first
   // renders the row labels. This ref is used
-  // to populate rowHeights so that row heights for all
+  // to populate rowBodyHeights so that row heights for all
   // vintages have the same heights as the corresponding row in the first vintage
   const ref = useRef<HTMLTableElement>(null);
   const category = useCategory();
@@ -35,10 +34,18 @@ export const VintageList = ({
     ref.current?.querySelectorAll("tbody tr").forEach((node) => {
       heights.push(node.clientHeight);
     });
-    setRowHeights(heights);
+    setRowBodyHeights(heights);
   }, [category, subgroup]);
 
-  // TODO: create effect to get header heights
+  // TODO: look into generalizing grabbing the heights of the elements
+  useEffect(() => {
+    const heights: number[] = [];
+    ref.current?.querySelectorAll("thead tr").forEach((node) => {
+      heights.push(node.clientHeight);
+    });
+    setRowHeaderHeights(heights);
+    // TODO: check what causes changes to headers
+  }, [category, subgroup]);
 
   return (
     <Flex
@@ -55,7 +62,8 @@ export const VintageList = ({
               ref={ref}
               key={`vintage-${i}`}
               vintage={vintage}
-              rowHeights={rowHeights}
+              rowHeaderHeights={rowHeaderHeights}
+              rowBodyHeights={rowBodyHeights}
               shouldShowReliability={shouldShowReliability}
               isSurvey={isSurvey}
             />
@@ -65,8 +73,8 @@ export const VintageList = ({
           <VintageTable
             key={`vintage-${i}`}
             vintage={vintage}
-            // TODO: refactor to body heights
-            rowHeights={rowHeights}
+            rowHeaderHeights={rowHeaderHeights}
+            rowBodyHeights={rowBodyHeights}
             shouldShowReliability={shouldShowReliability}
             isSurvey={isSurvey}
           />

--- a/src/components/VintageList/VintageList.tsx
+++ b/src/components/VintageList/VintageList.tsx
@@ -33,7 +33,7 @@ export const VintageList = ({
   // This ref is passed to the first VintageTable for the indicator
   // When multiple VintageTables are stacked horizontally on desktop, only the first
   // renders the row labels. This ref is used
-  // to populate rowBodyHeights so that row heights for all
+  // to populate rowBodyHeights and rowHeaderHeights so that row heights for all
   // vintages have the same heights as the corresponding row in the first vintage
   const ref = useRef<HTMLTableElement>(null);
   const category = useCategory();
@@ -63,6 +63,7 @@ export const VintageList = ({
             <VintageTable
               ref={ref}
               key={`vintage-${i}`}
+              isFirstVintage={true}
               vintage={vintage}
               rowHeaderHeights={rowHeaderHeights}
               rowBodyHeights={rowBodyHeights}
@@ -74,6 +75,7 @@ export const VintageList = ({
         return (
           <VintageTable
             key={`vintage-${i}`}
+            isFirstVintage={false}
             vintage={vintage}
             rowHeaderHeights={rowHeaderHeights}
             rowBodyHeights={rowBodyHeights}

--- a/src/components/VintageList/VintageList.tsx
+++ b/src/components/VintageList/VintageList.tsx
@@ -16,6 +16,8 @@ export const VintageList = ({
   shouldShowReliability,
   isSurvey,
 }: VintageListProps) => {
+  // TODO: create headerHeights state
+  // TODO: refactor to body heights
   const [rowHeights, setRowHeights] = useState<number[]>([]);
 
   // This ref is passed to the first VintageTable for the indicator
@@ -35,6 +37,8 @@ export const VintageList = ({
     });
     setRowHeights(heights);
   }, [category, subgroup]);
+
+  // TODO: create effect to get header heights
 
   return (
     <Flex
@@ -61,6 +65,7 @@ export const VintageList = ({
           <VintageTable
             key={`vintage-${i}`}
             vintage={vintage}
+            // TODO: refactor to body heights
             rowHeights={rowHeights}
             shouldShowReliability={shouldShowReliability}
             isSurvey={isSurvey}

--- a/src/components/VintageList/VintageList.tsx
+++ b/src/components/VintageList/VintageList.tsx
@@ -44,8 +44,7 @@ export const VintageList = ({
       heights.push(node.clientHeight);
     });
     setRowHeaderHeights(heights);
-    // TODO: check what causes changes to headers
-  }, [category, subgroup]);
+  }, [category, subgroup, shouldShowReliability]);
 
   return (
     <Flex

--- a/src/components/VintageTable/VintageTable.tsx
+++ b/src/components/VintageTable/VintageTable.tsx
@@ -6,15 +6,23 @@ import { Vintage } from "@schemas/vintage";
 import { useTablesIsOpen } from "@contexts/TablesIsOpenContext";
 export interface VintageTableProps {
   vintage: Vintage;
-  // TODO: Variable for header heights
-  // TODO: refactor to body heights
-  rowHeights: number[];
+  rowHeaderHeights: number[];
+  rowBodyHeights: number[];
   shouldShowReliability: boolean;
   isSurvey: boolean;
 }
 
 const VintageTable = forwardRef<HTMLTableElement, VintageTableProps>(
-  ({ vintage, rowHeights, shouldShowReliability, isSurvey }, ref) => {
+  (
+    {
+      vintage,
+      rowBodyHeights,
+      rowHeaderHeights,
+      shouldShowReliability,
+      isSurvey,
+    },
+    ref
+  ) => {
     const { rows, headers, label, isChange } = vintage;
     const [isOpen, setIsOpen] = useState(true);
 
@@ -49,8 +57,7 @@ const VintageTable = forwardRef<HTMLTableElement, VintageTableProps>(
         }}
       >
         <Thead>
-          <Tr>
-            {/* TODO: use height of first row for first table  */}
+          <Tr height={rowHeaderHeights[0]}>
             <Th
               rowSpan={headers.length + 1}
               display={{ base: "none", md: "table-cell" }}
@@ -122,7 +129,7 @@ const VintageTable = forwardRef<HTMLTableElement, VintageTableProps>(
                 just render first row of headers with colspan of 1 */}
           {isSurvey && !shouldShowReliability ? (
             <Tr
-              // TODO: render the second row for the header rows
+              height={rowHeaderHeights[1]}
               display={{
                 base: isOpen ? "table-row" : "none",
                 md: "table-row",
@@ -167,7 +174,7 @@ const VintageTable = forwardRef<HTMLTableElement, VintageTableProps>(
             // Otherwise, render all header rows, taking colspans from the data
             headers.map((headerRow, i, headers) => (
               <Tr
-                // TODO: render the second through last header rows
+                height={rowHeaderHeights[i + 1]}
                 display={{
                   base: isOpen ? "table-row" : "none",
                   md: "table-row",
@@ -223,7 +230,7 @@ const VintageTable = forwardRef<HTMLTableElement, VintageTableProps>(
           {rows.map((row, i) => (
             <DataPointRow
               shouldShowReliability={shouldShowReliability}
-              height={rowHeights[i]}
+              height={rowBodyHeights[i]}
               key={i}
               row={row}
             />

--- a/src/components/VintageTable/VintageTable.tsx
+++ b/src/components/VintageTable/VintageTable.tsx
@@ -4,7 +4,11 @@ import { ChevronDownIcon } from "@chakra-ui/icons";
 import { DataPointRow } from "@components/DataPointRow";
 import { Vintage } from "@schemas/vintage";
 import { useTablesIsOpen } from "@contexts/TablesIsOpenContext";
+
 export interface VintageTableProps {
+  // The first vintage in the list is the reference for the other vintages.
+  // Its height needs to be free to respond to changes.
+  isFirstVintage: boolean;
   vintage: Vintage;
   rowHeaderHeights: number[];
   rowBodyHeights: number[];
@@ -15,6 +19,7 @@ export interface VintageTableProps {
 const VintageTable = forwardRef<HTMLTableElement, VintageTableProps>(
   (
     {
+      isFirstVintage,
       vintage,
       rowBodyHeights,
       rowHeaderHeights,
@@ -57,7 +62,7 @@ const VintageTable = forwardRef<HTMLTableElement, VintageTableProps>(
         }}
       >
         <Thead>
-          <Tr height={rowHeaderHeights[0]}>
+          <Tr height={!isFirstVintage ? rowHeaderHeights[0] : undefined}>
             <Th
               rowSpan={headers.length + 1}
               display={{ base: "none", md: "table-cell" }}
@@ -129,7 +134,7 @@ const VintageTable = forwardRef<HTMLTableElement, VintageTableProps>(
                 just render first row of headers with colspan of 1 */}
           {isSurvey && !shouldShowReliability ? (
             <Tr
-              height={rowHeaderHeights[1]}
+              height={!isFirstVintage ? rowHeaderHeights[1] : undefined}
               display={{
                 base: isOpen ? "table-row" : "none",
                 md: "table-row",
@@ -174,7 +179,7 @@ const VintageTable = forwardRef<HTMLTableElement, VintageTableProps>(
             // Otherwise, render all header rows, taking colspans from the data
             headers.map((headerRow, i, headers) => (
               <Tr
-                height={rowHeaderHeights[i + 1]}
+                height={!isFirstVintage ? rowHeaderHeights[i + 1] : undefined}
                 display={{
                   base: isOpen ? "table-row" : "none",
                   md: "table-row",

--- a/src/components/VintageTable/VintageTable.tsx
+++ b/src/components/VintageTable/VintageTable.tsx
@@ -6,6 +6,8 @@ import { Vintage } from "@schemas/vintage";
 import { useTablesIsOpen } from "@contexts/TablesIsOpenContext";
 export interface VintageTableProps {
   vintage: Vintage;
+  // TODO: Variable for header heights
+  // TODO: refactor to body heights
   rowHeights: number[];
   shouldShowReliability: boolean;
   isSurvey: boolean;
@@ -48,6 +50,7 @@ const VintageTable = forwardRef<HTMLTableElement, VintageTableProps>(
       >
         <Thead>
           <Tr>
+            {/* TODO: use height of first row for first table  */}
             <Th
               rowSpan={headers.length + 1}
               display={{ base: "none", md: "table-cell" }}
@@ -119,6 +122,7 @@ const VintageTable = forwardRef<HTMLTableElement, VintageTableProps>(
                 just render first row of headers with colspan of 1 */}
           {isSurvey && !shouldShowReliability ? (
             <Tr
+              // TODO: render the second row for the header rows
               display={{
                 base: isOpen ? "table-row" : "none",
                 md: "table-row",
@@ -163,6 +167,7 @@ const VintageTable = forwardRef<HTMLTableElement, VintageTableProps>(
             // Otherwise, render all header rows, taking colspans from the data
             headers.map((headerRow, i, headers) => (
               <Tr
+                // TODO: render the second through last header rows
                 display={{
                   base: isOpen ? "table-row" : "none",
                   md: "table-row",


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
Only table body/data rows were being standardized across all vintages. The table header rows also needed to be standardized.

This solution assumes the content and structure of the first vintage will be appropriate for all subsequent vintages. This assumption holds true throughout the current site layout and data content. This assumption may need to be revisited if there are significant changes to the data or layout. 

It also adds a note on where to find the development credentials

#### Tasks/Bug Numbers
 - Fixes [AB#12305](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/12305)

### Technical Explanation
This takes the same approach used to standardize the data row heights. It collects the heights of the first vintage and applies it to the rest of the vintages. If am I reading the code correctly, it deviates from the original approach in that it does not set the height for the first vintage. Instead, it leaves the height of the first vintage undefined in order to let it remain responsive. 