### PR TITLE
note the location of development credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ npm i
 This command should install all necessary dependencies and set up Husky to run on all commits
 
 2. Create `.env.local` and set the required environment variables.
+   - Local development credentials are available within the NYC planning password vault under "EDDE Credentials"
 
 
 ### Running locally


### PR DESCRIPTION
Update README with the location of development credentials. This change was meant to be part of the table refactor PR. However, it was lost in the branch switching.
