### PR TITLE
Add CODEOWNERS file refering to OSE reviewer team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@NYCPlanning/open-source-engineering-reviewers


### PR DESCRIPTION
### Summary

This PR adds a `CODEOWNERS` file with the correct team.