### PR TITLE
Comment out e2e GH action step and set environment URLs for staging and production

### DIFF
--- a/.github/workflows/feature_branch.yml
+++ b/.github/workflows/feature_branch.yml
@@ -37,37 +37,37 @@ jobs:
       - name: Run tests
         run: npm run test
 
-  e2e:
-    name: 🧪 End To End Tests
-    needs:
-      - lint
-    runs-on: ubuntu-latest
-    environment: development
-    env:
-      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-      NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
-      NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
-      NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
-      NEXT_PUBLIC_DO_SPACE_URL: ${{ secrets.DO_SPACE_URL }}
-      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      WAIT_ON_TIMEOUT: 900000
-      SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
-      FROM_EDDE_EMAIL: ${{ secrets.FROM_EDDE_EMAIL }}
-      TO_EDDE_EMAIL: ${{ secrets.TO_EDDE_EMAIL }}
-      NEWSLETTER_ENDPOINT: ${{ secrets.NEWSLETTER_ENDPOINT }}
-      NEWSLETTER_LIST_ID: ${{secrets.NEWSLETTER_LIST_ID}}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup node env
-        uses: actions/setup-node@v2.1.2
-        with:
-          node-version: 16.13
-      - name: Install dependencies
-        run: npm ci
-      - name: Run e2e test
-        run: npm run e2e:test
+  # e2e:
+  #   name: 🧪 End To End Tests
+  #   needs:
+  #     - lint
+  #   runs-on: ubuntu-latest
+  #   environment: development
+  #   env:
+  #     NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+  #     NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+  #     NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
+  #     NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
+  #     NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
+  #     NEXT_PUBLIC_DO_SPACE_URL: ${{ secrets.DO_SPACE_URL }}
+  #     SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+  #     SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+  #     WAIT_ON_TIMEOUT: 900000
+  #     SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
+  #     FROM_EDDE_EMAIL: ${{ secrets.FROM_EDDE_EMAIL }}
+  #     TO_EDDE_EMAIL: ${{ secrets.TO_EDDE_EMAIL }}
+  #     NEWSLETTER_ENDPOINT: ${{ secrets.NEWSLETTER_ENDPOINT }}
+  #     NEWSLETTER_LIST_ID: ${{secrets.NEWSLETTER_LIST_ID}}
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Setup node env
+  #       uses: actions/setup-node@v2.1.2
+  #       with:
+  #         node-version: 16.13
+  #     - name: Install dependencies
+  #       run: npm ci
+  #     - name: Run e2e test
+  #       run: npm run e2e:test
 
   deploy-preview:
     name: Preview Deploy

--- a/.github/workflows/pr_merged.yml
+++ b/.github/workflows/pr_merged.yml
@@ -38,44 +38,46 @@ jobs:
       - name: Run tests
         run: npm run test
 
-  e2e:
-    name: 🧪 End To End Tests
-    needs:
-      - lint
-    runs-on: ubuntu-latest
-    environment: staging
-    env:
-      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-      NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
-      NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
-      NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
-      NEXT_PUBLIC_DO_SPACE_URL: ${{ secrets.DO_SPACE_URL }}
-      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      WAIT_ON_TIMEOUT: 900000
-      SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
-      FROM_EDDE_EMAIL: ${{ secrets.FROM_EDDE_EMAIL }}
-      TO_EDDE_EMAIL: ${{ secrets.TO_EDDE_EMAIL }}
-      NEWSLETTER_ENDPOINT: ${{ secrets.NEWSLETTER_ENDPOINT }}
-      NEWSLETTER_LIST_ID: ${{secrets.NEWSLETTER_LIST_ID}}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup node env
-        uses: actions/setup-node@v2.1.2
-        with:
-          node-version: 16
-      - name: Install dependencies
-        run: npm ci
-      - name: Run e2e test
-        run: npm run e2e:test
+  # e2e:
+  #   name: 🧪 End To End Tests
+  #   needs:
+  #     - lint
+  #   runs-on: ubuntu-latest
+  #   environment: staging
+  #   env:
+  #     NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+  #     NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+  #     NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
+  #     NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
+  #     NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
+  #     NEXT_PUBLIC_DO_SPACE_URL: ${{ secrets.DO_SPACE_URL }}
+  #     SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+  #     SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+  #     WAIT_ON_TIMEOUT: 900000
+  #     SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
+  #     FROM_EDDE_EMAIL: ${{ secrets.FROM_EDDE_EMAIL }}
+  #     TO_EDDE_EMAIL: ${{ secrets.TO_EDDE_EMAIL }}
+  #     NEWSLETTER_ENDPOINT: ${{ secrets.NEWSLETTER_ENDPOINT }}
+  #     NEWSLETTER_LIST_ID: ${{secrets.NEWSLETTER_LIST_ID}}
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Setup node env
+  #       uses: actions/setup-node@v2.1.2
+  #       with:
+  #         node-version: 16
+  #     - name: Install dependencies
+  #       run: npm ci
+  #     - name: Run e2e test
+  #       run: npm run e2e:test
 
   deploy-preview:
     name: Preview Deploy
     needs:
       - lint
     runs-on: ubuntu-latest
-    environment: staging
+    environment:
+      name: staging
+      url: https://staging-equitableexplorer.planninglabs.nyc
     env:
       NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
       NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/release_and_deploy.yml
+++ b/.github/workflows/release_and_deploy.yml
@@ -37,46 +37,48 @@ jobs:
       - name: Run tests
         run: npm run test
 
-  e2e:
-    name: 🧪 End To End Tests
-    needs:
-      - lint
-    runs-on: ubuntu-latest
-    environment: production
-    env:
-      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-      NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
-      NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
-      NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
-      NEXT_PUBLIC_DO_SPACE_URL: ${{ secrets.DO_SPACE_URL }}
-      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      WAIT_ON_TIMEOUT: 900000
-      SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
-      FROM_EDDE_EMAIL: ${{ secrets.FROM_EDDE_EMAIL }}
-      TO_EDDE_EMAIL: ${{ secrets.TO_EDDE_EMAIL }}
-      NEWSLETTER_ENDPOINT: ${{ secrets.NEWSLETTER_ENDPOINT }}
-      NEWSLETTER_LIST_ID: ${{secrets.NEWSLETTER_LIST_ID}}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: 'main'
-      - name: Setup node env
-        uses: actions/setup-node@v2.1.2
-        with:
-          node-version: 16
-      - name: Install dependencies
-        run: npm ci
-      - name: Run e2e test
-        run: npm run e2e:test
+  # e2e:
+  #   name: 🧪 End To End Tests
+  #   needs:
+  #     - lint
+  #   runs-on: ubuntu-latest
+  #   environment: production
+  #   env:
+  #     NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+  #     NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+  #     NEXT_PUBLIC_CARTO_USERNAME: ${{ secrets.CARTO_USERNAME }}
+  #     NEXT_PUBLIC_CARTO_API_KEY: ${{ secrets.CARTO_API_KEY }}
+  #     NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
+  #     NEXT_PUBLIC_DO_SPACE_URL: ${{ secrets.DO_SPACE_URL }}
+  #     SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+  #     SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+  #     WAIT_ON_TIMEOUT: 900000
+  #     SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
+  #     FROM_EDDE_EMAIL: ${{ secrets.FROM_EDDE_EMAIL }}
+  #     TO_EDDE_EMAIL: ${{ secrets.TO_EDDE_EMAIL }}
+  #     NEWSLETTER_ENDPOINT: ${{ secrets.NEWSLETTER_ENDPOINT }}
+  #     NEWSLETTER_LIST_ID: ${{secrets.NEWSLETTER_LIST_ID}}
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         ref: 'main'
+  #     - name: Setup node env
+  #       uses: actions/setup-node@v2.1.2
+  #       with:
+  #         node-version: 16
+  #     - name: Install dependencies
+  #       run: npm ci
+  #     - name: Run e2e test
+  #       run: npm run e2e:test
 
   version-deploy:
     name: 🚀 Version and Deploy
     needs:
       - lint
     runs-on: ubuntu-latest
-    environment: production
+    environment:
+      name: production
+      url: https://equitableexplorer.planning.nyc.gov
     env:
         NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}


### PR DESCRIPTION
### Summary
This PR does two things:
* Comments out the `e2e` job in each action workflow. These tests have been failing for a while and until we figure out a way to have them behave correctly inside of GH action runners, I think it's best to comment out the step so that the entire workflow run isn't classified as "failed". I [looked into it](https://github.com/actions/runner/issues/2347), but there doesn't seem to be a way to "allow" a particular job in a workflow to fail.
* Sets a `url` under `environment` in the pr_merged and release_and_deploy workflows. This should trigger GH to associate that URL with the environments listed on the homepage of the repo. Note that I didn't do that the feature_branch workflow because that will a little more involved, as those urls are dynamic but we should do that in the near future as well. Here's some [documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-output-as-url) and a [SO post](https://stackoverflow.com/a/67385569) that should help with that.