### PR TITLE
Cleaning up some `any` types

### DIFF
--- a/src/components/BackToTop/BackToTop.tsx
+++ b/src/components/BackToTop/BackToTop.tsx
@@ -3,7 +3,10 @@ import { Box, Button, Link } from "@chakra-ui/react";
 
 export const BackToTop = () => {
   const scrollToTop = () => {
-    document.getElementById("back-to-top")!.scrollTop = 0;
+    const backToTopElement = document.getElementById("back-to-top");
+    if (backToTopElement !== null) {
+      backToTopElement.scrollTop = 0;
+    }
   };
 
   return (

--- a/src/components/GeographyInfo/GeographyInfo.tsx
+++ b/src/components/GeographyInfo/GeographyInfo.tsx
@@ -1,8 +1,7 @@
 import { Heading, Box, BoxProps } from "@chakra-ui/react";
 import { usePumaInfo } from "@hooks/usePumaInfo";
-import { fetchNtaInfo, NtaInfo } from "@helpers/fetchNtaInfo";
+import { useNtaInfo } from "@hooks/useNtaInfo";
 import { Geography } from "@constants/geography";
-import { useEffect, useState } from "react";
 import { getBoroughName } from "@helpers/getBoroughName";
 
 export interface GeographyInfoProps extends BoxProps {
@@ -21,17 +20,7 @@ export const GeographyInfo = ({
 
   const pumaInfo = usePumaInfo();
 
-  const [ntaInfo, setNtaInfo] = useState<NtaInfo>({
-    ntaname: "",
-    ntacode: "",
-  });
-
-  useEffect(() => {
-    geography === Geography.NTA &&
-      fetchNtaInfo(geoid, (ntaInfo: NtaInfo) => {
-        setNtaInfo(ntaInfo);
-      });
-  }, [geoid]);
+  const ntaInfo = useNtaInfo();
 
   let primaryHeading = "";
 
@@ -46,7 +35,7 @@ export const GeographyInfo = ({
       primaryHeading = "Citywide";
       break;
     case NTA:
-      primaryHeading = `${ntaInfo?.ntaname}`;
+      primaryHeading = `${ntaInfo.ntaname}`;
       break;
     default:
       break;

--- a/src/components/GeographyInfo/GeographyInfo.tsx
+++ b/src/components/GeographyInfo/GeographyInfo.tsx
@@ -1,6 +1,6 @@
 import { Heading, Box, BoxProps } from "@chakra-ui/react";
 import { usePumaInfo } from "@hooks/usePumaInfo";
-import { fetchNtaInfo } from "@helpers/fetchNtaInfo";
+import { fetchNtaInfo, NtaInfo } from "@helpers/fetchNtaInfo";
 import { Geography } from "@constants/geography";
 import { useEffect, useState } from "react";
 import { getBoroughName } from "@helpers/getBoroughName";
@@ -21,14 +21,14 @@ export const GeographyInfo = ({
 
   const pumaInfo = usePumaInfo();
 
-  const [ntaInfo, setNtaInfo] = useState({
+  const [ntaInfo, setNtaInfo] = useState<NtaInfo>({
     ntaname: "",
     ntacode: "",
   });
 
   useEffect(() => {
     geography === Geography.NTA &&
-      fetchNtaInfo(geoid, (ntaInfo: any) => {
+      fetchNtaInfo(geoid, (ntaInfo: NtaInfo) => {
         setNtaInfo(ntaInfo);
       });
   }, [geoid]);

--- a/src/components/Map/DRM/MobileDrawer.tsx
+++ b/src/components/Map/DRM/MobileDrawer.tsx
@@ -14,7 +14,7 @@ import { useGeography } from "@hooks/useGeography";
 import { NYC } from "@constants/geoid";
 import { SubindicatorBin } from "@components/SidebarContent";
 import { DataDownloadModal } from "@components/DataDownloadModal";
-import ntaIndexes from "@data/ntaIndexes.json";
+import { useNtaIndex } from "@hooks/useNtaIndex";
 import { View } from "@constants/View";
 
 export const DrmMobileDrawer = () => {
@@ -26,7 +26,7 @@ export const DrmMobileDrawer = () => {
 
   const clearSelection = useClearSelection();
 
-  const ntaIndex: { [index: string]: any } = ntaIndexes;
+  const ntaIndex = useNtaIndex();
 
   return (
     <Box
@@ -134,11 +134,7 @@ export const DrmMobileDrawer = () => {
             />
           </Box>
 
-          <Box>
-            {view === View.DRM && (
-              <SubindicatorBin bin={ntaIndex[geoid ? geoid : ""]} />
-            )}
-          </Box>
+          <Box>{view === View.DRM && <SubindicatorBin bin={ntaIndex} />}</Box>
           <DRMSelection />
         </Box>
       </Flex>

--- a/src/components/SidebarContent/DRMSelection/DRMSelection.tsx
+++ b/src/components/SidebarContent/DRMSelection/DRMSelection.tsx
@@ -1,14 +1,11 @@
 import React from "react";
-import drmData from "@data/DRI_Subindices_Indicators.json";
 import { Box, Divider } from "@chakra-ui/react";
-import { useGeoid } from "@hooks/useGeoid";
 import { Subindicator } from "./Subindicator";
 import { DataPoint } from "./DataPoint";
+import { useSubindexSelection } from "@hooks/useSubindexSelection";
 
 export const DRMSelection = () => {
-  const geoid = useGeoid();
-
-  const selectedDRMdata = drmData.find((nta: any) => nta.ntacode === geoid);
+  const selection = useSubindexSelection();
 
   return (
     <>
@@ -16,31 +13,31 @@ export const DRMSelection = () => {
       <Box p="0rem 1rem 0rem 1rem">
         <Subindicator
           subindicatorTitle="Population Vulnerability"
-          subindicatorBin={selectedDRMdata?.populationvulnerability_reclass}
+          subindicatorBin={selection?.populationvulnerability_reclass}
         />
         <DataPoint
           title="Non-white Population"
-          value={selectedDRMdata?.percentnotwhite}
+          value={selection?.percentnotwhite}
           percentage={true}
         />
         <Divider borderColor="gray.100" />
         <DataPoint
           title="Population with income below 200% of Federal poverty rate"
-          value={selectedDRMdata?.percentbelow2xpovertyrate}
+          value={selection?.percentbelow2xpovertyrate}
           percentage={true}
-          moe={selectedDRMdata?.percentbelow2xpovertyrate_moe}
+          moe={selection?.percentbelow2xpovertyrate_moe}
         />
         <Divider borderColor="gray.100" />
         <DataPoint
           title="limited-English speaking population"
-          value={selectedDRMdata?.limitedenglishproficiency}
+          value={selection?.limitedenglishproficiency}
           percentage={true}
-          moe={selectedDRMdata?.limitedenglishproficiency_moe}
+          moe={selection?.limitedenglishproficiency_moe}
         />
         <Divider borderColor="gray.100" />
         <DataPoint
           title="households with severe rent burden"
-          value={selectedDRMdata?.percentrentburdenedvscity}
+          value={selection?.percentrentburdenedvscity}
           percentage={false}
           noNumber={true}
         />
@@ -49,66 +46,64 @@ export const DRMSelection = () => {
       <Box p="0rem 1rem 0rem 1rem">
         <Subindicator
           subindicatorTitle="Housing Conditions"
-          subindicatorBin={selectedDRMdata?.housingconditions_reclass}
+          subindicatorBin={selection?.housingconditions_reclass}
         />
         <DataPoint
           title="housing with 3+ maintenance deficiencies"
-          value={
-            selectedDRMdata?.percentunitswith3plusmaintenancedeficienciesvscity
-          }
+          value={selection?.percentunitswith3plusmaintenancedeficienciesvscity}
           percentage={false}
           noNumber={true}
         />
         <Divider borderColor="gray.100" />
         <DataPoint
           title="Housing that is not Income-Restricted"
-          value={selectedDRMdata?.percentunitswithnoincomerestrictions}
+          value={selection?.percentunitswithnoincomerestrictions}
           percentage={true}
         />
         <Divider borderColor="gray.100" />
         <DataPoint
           title="Housing that is not Rent-Stabilized"
-          value={selectedDRMdata?.percentunitswithrentregulationsvscity}
+          value={selection?.percentunitswithrentregulationsvscity}
           percentage={false}
           noNumber={true}
         />
         <Divider borderColor="gray.100" />
         <DataPoint
           title="renter-occupied housing units"
-          value={selectedDRMdata?.percentrenters}
+          value={selection?.percentrenters}
           percentage={true}
-          moe={selectedDRMdata?.percentrenters_moe}
+          moe={selection?.percentrenters_moe}
         />
       </Box>
       <Divider borderColor="gray.400" />
       <Box p="0rem 1rem 0rem 1rem">
         <Subindicator
           subindicatorTitle="Market Pressure"
-          subindicatorBin={selectedDRMdata?.marketpressure_reclass}
+          subindicatorBin={selection?.marketpressure_reclass}
         />
         <DataPoint
           title="Rent Change Vs. City"
-          value={selectedDRMdata?.changeinrentsvscity}
+          value={selection?.changeinrentsvscity}
           percentage={false}
           noNumber={true}
         />
         <Divider borderColor="gray.100" />
         <DataPoint
           title="Residential Property Price Appreciation 2000-2020"
-          value={selectedDRMdata?.salespriceappreciation}
+          value={selection?.salespriceappreciation}
           percentage={false}
         />
         <Divider borderColor="gray.100" />
         <DataPoint
           title="Bachelors degree Or Higher Change"
-          value={selectedDRMdata?.changeinpopulationwithbachelorsdegreesvscity}
+          value={selection?.changeinpopulationwithbachelorsdegreesvscity}
           percentage={false}
           noNumber={true}
         />
         <Divider borderColor="gray.100" />
         <DataPoint
           title="Adjacent Neighborhood Pressure"
-          value={selectedDRMdata?.adjacency}
+          value={selection?.adjacency}
           percentage={false}
           noNumber={true}
         />

--- a/src/components/SidebarContent/DRMSelection/DataPoint.tsx
+++ b/src/components/SidebarContent/DRMSelection/DataPoint.tsx
@@ -4,7 +4,7 @@ import { Heading, Text, Box, Flex } from "@chakra-ui/react";
 interface DataPointProps {
   title: string;
   noNumber?: boolean | null;
-  value: any | null;
+  value: string | number | undefined | null;
   percentage?: boolean | null;
   moe?: number | null;
 }

--- a/src/components/SidebarContent/DRMSelection/SubindicatorBin.tsx
+++ b/src/components/SidebarContent/DRMSelection/SubindicatorBin.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { Tag } from "@chakra-ui/react";
+import { NtaIndex } from "@hooks/useNtaIndex";
 
 interface SubindicatorBinProps {
-  bin: string | undefined;
+  bin: NtaIndex | null;
 }
 
 export const SubindicatorBin = ({ bin }: SubindicatorBinProps) => {

--- a/src/components/SidebarContent/SidebarContent.tsx
+++ b/src/components/SidebarContent/SidebarContent.tsx
@@ -7,13 +7,13 @@ import WelcomeFooter from "@components/Footers/WelcomeFooter";
 import { DRMSelection } from "@components/SidebarContent/DRMSelection";
 import { useView } from "@hooks/useView";
 import { useGeoid } from "@hooks/useGeoid";
+import { useNtaIndex } from "@hooks/useNtaIndex";
 import { useGeography } from "@hooks/useGeography";
 import { useClearSelection } from "@helpers/useClearSelection";
 import { NYC } from "@constants/geoid";
 import { Geography } from "@constants/geography";
 import { CategoryMenu } from "@components/CategoryMenu";
 import { SubindicatorBin } from "@components/SidebarContent";
-import ntaIndexes from "@data/ntaIndexes.json";
 import { DataDownloadModal } from "@components/DataDownloadModal";
 import { View } from "@constants/View";
 
@@ -22,7 +22,7 @@ export const SidebarContent = () => {
   const geoid = useGeoid();
   const geography = useGeography();
   const clearSelection = useClearSelection();
-  const ntaIndex: { [index: string]: any } = ntaIndexes;
+  const ntaIndex = useNtaIndex();
 
   if (geoid != null) {
     return (
@@ -70,9 +70,7 @@ export const SidebarContent = () => {
             />
           </Box>
         </Flex>
-        <Box>
-          {view === View.DRM && <SubindicatorBin bin={ntaIndex[geoid]} />}
-        </Box>
+        <Box>{view === View.DRM && <SubindicatorBin bin={ntaIndex} />}</Box>
 
         {view === View.DRM && <DRMSelection />}
         {view === View.DATA && (

--- a/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -18,7 +18,7 @@ export const ToggleButtonGroup: React.FC<ToggleButtonGroupInterface> = (
   const styles = useMultiStyleConfig("ButtonGroup", { variant: "toggle" });
 
   return (
-    <ButtonGroup isAttached __css={styles.group} {...rest}>
+    <ButtonGroup isAttached={isAttached} __css={styles.group} {...rest}>
       <StylesProvider value={styles}>{children}</StylesProvider>
     </ButtonGroup>
   );

--- a/src/helpers/fetchNtaInfo.ts
+++ b/src/helpers/fetchNtaInfo.ts
@@ -1,6 +1,11 @@
+export type NtaInfo = {
+  ntacode: string;
+  ntaname: string;
+};
+
 export const fetchNtaInfo = async (
   ntacode: string | null,
-  onNtaInfo: (ntaInfo: any) => void
+  onNtaInfo: (ntaInfo: NtaInfo) => void
 ): Promise<null> => {
   if (!ntacode) return null;
 

--- a/src/helpers/pause.ts
+++ b/src/helpers/pause.ts
@@ -1,3 +1,0 @@
-export function pause(ms = 0): any {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}

--- a/src/hooks/useGeoidDescription/useGeoidDescription.ts
+++ b/src/hooks/useGeoidDescription/useGeoidDescription.ts
@@ -1,10 +1,9 @@
-import { useEffect, useState } from "react";
 import { useGeography } from "@hooks/useGeography";
 import { useGeoid } from "@hooks/useGeoid/useGeoid";
 import { usePumaInfo } from "@hooks/usePumaInfo";
 import { Geography } from "@constants/geography";
 import { getBoroughName } from "@helpers/getBoroughName";
-import { fetchNtaInfo, NtaInfo } from "@helpers/fetchNtaInfo";
+import { useNtaInfo } from "@hooks/useNtaInfo";
 
 export interface GeoidDescription {
   id: string;
@@ -18,17 +17,7 @@ export const useGeoidDescription = (): GeoidDescription => {
 
   const pumaInfo = usePumaInfo();
 
-  const [ntaInfo, setNtaInfo] = useState<NtaInfo>({
-    ntaname: "",
-    ntacode: "",
-  });
-
-  useEffect(() => {
-    geography === Geography.NTA &&
-      fetchNtaInfo(geoid, (ntaInfo: NtaInfo) => {
-        setNtaInfo(ntaInfo);
-      });
-  }, [geoid]);
+  const ntaInfo = useNtaInfo();
 
   if (geoid === null) {
     return {

--- a/src/hooks/useGeoidDescription/useGeoidDescription.ts
+++ b/src/hooks/useGeoidDescription/useGeoidDescription.ts
@@ -4,7 +4,7 @@ import { useGeoid } from "@hooks/useGeoid/useGeoid";
 import { usePumaInfo } from "@hooks/usePumaInfo";
 import { Geography } from "@constants/geography";
 import { getBoroughName } from "@helpers/getBoroughName";
-import { fetchNtaInfo } from "@helpers/fetchNtaInfo";
+import { fetchNtaInfo, NtaInfo } from "@helpers/fetchNtaInfo";
 
 export interface GeoidDescription {
   id: string;
@@ -18,14 +18,14 @@ export const useGeoidDescription = (): GeoidDescription => {
 
   const pumaInfo = usePumaInfo();
 
-  const [ntaInfo, setNtaInfo] = useState({
+  const [ntaInfo, setNtaInfo] = useState<NtaInfo>({
     ntaname: "",
     ntacode: "",
   });
 
   useEffect(() => {
     geography === Geography.NTA &&
-      fetchNtaInfo(geoid, (ntaInfo: any) => {
+      fetchNtaInfo(geoid, (ntaInfo: NtaInfo) => {
         setNtaInfo(ntaInfo);
       });
   }, [geoid]);
@@ -54,7 +54,6 @@ export const useGeoidDescription = (): GeoidDescription => {
         label: "Citywide",
       };
     case NTA:
-      // primaryHeading = `${ntaInfo?.ntaname}`;
       return {
         id: `NTA: ${geoid}`,
         label: ntaInfo.ntaname,

--- a/src/hooks/useNtaIndex/index.ts
+++ b/src/hooks/useNtaIndex/index.ts
@@ -1,0 +1,1 @@
+export * from "./useNtaIndex";

--- a/src/hooks/useNtaIndex/useNtaIndex.ts
+++ b/src/hooks/useNtaIndex/useNtaIndex.ts
@@ -1,0 +1,18 @@
+import ntaIndexes from "@data/ntaIndexes.json";
+import { useGeoid } from "@hooks/useGeoid";
+import { hasOwnProperty } from "@helpers/hasOwnProperty";
+
+export type NtaIndex =
+  | "Lowest"
+  | "Lower"
+  | "Intermediate"
+  | "Higher"
+  | "Highest";
+
+export const useNtaIndex = (id?: string | null): NtaIndex | null => {
+  let geoid = useGeoid();
+  if (id) geoid = id;
+  if (!geoid || !hasOwnProperty(ntaIndexes, geoid)) return null;
+
+  return ntaIndexes[geoid] as NtaIndex;
+};

--- a/src/hooks/useNtaInfo/index.ts
+++ b/src/hooks/useNtaInfo/index.ts
@@ -1,0 +1,1 @@
+export * from "./useNtaInfo";

--- a/src/hooks/useNtaInfo/useNtaInfo.ts
+++ b/src/hooks/useNtaInfo/useNtaInfo.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+import { useGeography } from "@hooks/useGeography";
+import { useGeoid } from "@hooks/useGeoid";
+import { fetchNtaInfo, NtaInfo } from "@helpers/fetchNtaInfo";
+import { Geography } from "@constants/geography";
+
+export const useNtaInfo = (): NtaInfo => {
+  const geoid = useGeoid();
+  const geography = useGeography();
+  const [ntaInfo, setNtaInfo] = useState<NtaInfo>({
+    ntaname: "",
+    ntacode: "",
+  });
+
+  useEffect(() => {
+    geography === Geography.NTA &&
+      fetchNtaInfo(geoid, (ntaInfo: NtaInfo) => {
+        setNtaInfo(ntaInfo);
+      });
+  }, [geoid, geography]);
+
+  return ntaInfo;
+};

--- a/src/hooks/useSubindexSelection/index.ts
+++ b/src/hooks/useSubindexSelection/index.ts
@@ -1,0 +1,1 @@
+export * from "./useSubindexSelection";

--- a/src/hooks/useSubindexSelection/useSubindexSelection.ts
+++ b/src/hooks/useSubindexSelection/useSubindexSelection.ts
@@ -1,0 +1,14 @@
+import { useGeoid } from "@hooks/useGeoid";
+import drmData from "@data/DRI_Subindices_Indicators.json";
+
+export type SubindexSelection = typeof drmData[0];
+
+export const useSubindexSelection = (): SubindexSelection | null => {
+  const geoid = useGeoid();
+
+  const selection = drmData.find(
+    (nta: SubindexSelection) => nta.ntacode === geoid
+  );
+
+  return typeof selection === "undefined" ? null : selection;
+};

--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -1,5 +1,0 @@
-import type { NextApiRequest, NextApiResponse } from "next";
-
-export default (_req: NextApiRequest, res: NextApiResponse) => {
-  res.status(200).send("ok it works!");
-};


### PR DESCRIPTION
### Summary

This PR is an attempt to clean up some of the easier to address explicit `any` types in the project. Eventually we want to get this repo (and all of our TS code) to block explicit `any` as a part of linting. When we were first building this project, we accepted that that wouldn't be realistic on our timeline but we did forbid _implicit_ `any`s, so that clean up down the road would be easier and addressed them where we could in PRs. This PR remedies quite a few of them and refactors code where appropriate. This should result in fewer warnings in PR status checks.

I'm intentionally avoided the Deck.gl-related `any`s because those may be a little trickier to address properly and warrant there own PR. I addressed several of the `any`s that had to do with where we are importing raw JSON data with some new hooks - `useNtaInfo`, `useSubindexSelection`, and `useNtaIndex`. These hooks build on patterns established with hooks like `usePumaInfo`.

