### PR TITLE
Task/13262 ami footnote

### DIFF
--- a/src/components/Indicator/Indicator.tsx
+++ b/src/components/Indicator/Indicator.tsx
@@ -40,6 +40,7 @@ export const Indicator = ({
         )}
       </Flex>
       <VintageList
+        footnote={indicator.footnote}
         vintages={indicator.vintages}
         shouldShowReliability={shouldShowReliability}
         isSurvey={indicator.isSurvey}

--- a/src/components/VintageList/VintageList.tsx
+++ b/src/components/VintageList/VintageList.tsx
@@ -32,6 +32,7 @@ export const VintageList = ({
           {vintages.map((vintage, i) => (
             <VintageTableMobile
               key={`vintage-${i}`}
+              footnote={footnote}
               vintage={vintage}
               shouldShowReliability={shouldShowReliability}
               isSurvey={isSurvey}

--- a/src/components/VintageList/VintageList.tsx
+++ b/src/components/VintageList/VintageList.tsx
@@ -4,9 +4,11 @@ import {
   VintageTableDesktop,
   VintageTableMobile,
 } from "@components/VintageTable";
+import { Footnote } from "@schemas/footnote";
 
 export interface VintageListProps {
   vintages: Vintage[];
+  footnote: Footnote;
   shouldShowReliability: boolean;
   isSurvey: boolean;
 }
@@ -15,6 +17,7 @@ export const VintageList = ({
   vintages,
   shouldShowReliability,
   isSurvey,
+  footnote,
 }: VintageListProps) => {
   return (
     <>
@@ -39,6 +42,7 @@ export const VintageList = ({
       <Show above="md">
         <Flex overflowX="auto" paddingRight="1rem">
           <VintageTableDesktop
+            footnote={footnote}
             vintages={vintages}
             shouldShowReliability={shouldShowReliability}
             isSurvey={isSurvey}

--- a/src/components/VintageTable/Footnote/AMITableFootnote.tsx
+++ b/src/components/VintageTable/Footnote/AMITableFootnote.tsx
@@ -1,28 +1,36 @@
 import { Link, TableCaption, Text } from "@chakra-ui/react";
 
-export const AMITableFootnote = () => (
-  <TableCaption>
-    <Text align="left" paddingBottom={2} fontStyle="italic">
-      *AMI, or Area Median Income, refers to U.S. Housing and Urban Development
-      annual Income Limits for New York City. HUD establishes these Income
-      Limits each year to administer federal housing funds, such as housing tax
-      credits and rental assistance benefits. Each metropolitan area has unique
-      Income Limits. In government-administered affordable housing, these Income
-      Limits establish maximum eligible household incomes for new rentals or
-      homes for sale.
-    </Text>
-    <Text align="left" fontStyle="italic">
-      In New York City, because housing costs are so high, Income Limits are not
-      calculated using New Yorkers’ incomes. In NYC, Income Limits are based on
-      the income needed to afford currently available market rate housing. Learn
-      more about how HUD calculates NYC’s 2022 Income Limits here:{" "}
-      <Link
-        href="https://www.huduser.gov/portal/datasets/il/il2022/2022IlCalc.odn"
-        isExternal
-      >
-        FY 2022 Income Limits Documentation System -- Income Limits Calculations
-        for New York, NY HUD Metro FMR Area (huduser.gov)
-      </Link>
-    </Text>
-  </TableCaption>
-);
+interface AMITableFootnoteProps {
+  shouldDisplay: boolean;
+}
+
+export const AMITableFootnote = ({ shouldDisplay }: AMITableFootnoteProps) =>
+  shouldDisplay ? (
+    <TableCaption>
+      <Text align="left" paddingBottom={2} fontStyle="italic">
+        *AMI, or Area Median Income, refers to U.S. Housing and Urban
+        Development annual Income Limits for New York City. HUD establishes
+        these Income Limits each year to administer federal housing funds, such
+        as housing tax credits and rental assistance benefits. Each metropolitan
+        area has unique Income Limits. In government-administered affordable
+        housing, these Income Limits establish maximum eligible household
+        incomes for new rentals or homes for sale.
+      </Text>
+      <Text align="left" fontStyle="italic">
+        In New York City, because housing costs are so high, Income Limits are
+        not calculated using New Yorkers’ incomes. In NYC, Income Limits are
+        based on the income needed to afford currently available market rate
+        housing. Learn more about how HUD calculates NYC’s 2022 Income Limits
+        here:{" "}
+        <Link
+          href="https://www.huduser.gov/portal/datasets/il/il2022/2022IlCalc.odn"
+          isExternal
+        >
+          FY 2022 Income Limits Documentation System -- Income Limits
+          Calculations for New York, NY HUD Metro FMR Area (huduser.gov)
+        </Link>
+      </Text>
+    </TableCaption>
+  ) : (
+    <></>
+  );

--- a/src/components/VintageTable/Footnote/AMITableFootnote.tsx
+++ b/src/components/VintageTable/Footnote/AMITableFootnote.tsx
@@ -2,7 +2,7 @@ import { Link, TableCaption, Text } from "@chakra-ui/react";
 
 export const AMITableFootnote = () => (
   <TableCaption>
-    <Text>
+    <Text align="left" paddingBottom={2} fontStyle="italic">
       *AMI, or Area Median Income, refers to U.S. Housing and Urban Development
       annual Income Limits for New York City. HUD establishes these Income
       Limits each year to administer federal housing funds, such as housing tax
@@ -11,7 +11,7 @@ export const AMITableFootnote = () => (
       Limits establish maximum eligible household incomes for new rentals or
       homes for sale.
     </Text>
-    <Text>
+    <Text align="left" fontStyle="italic">
       In New York City, because housing costs are so high, Income Limits are not
       calculated using New Yorkers’ incomes. In NYC, Income Limits are based on
       the income needed to afford currently available market rate housing. Learn

--- a/src/components/VintageTable/Footnote/AMITableFootnote.tsx
+++ b/src/components/VintageTable/Footnote/AMITableFootnote.tsx
@@ -1,0 +1,28 @@
+import { Link, TableCaption, Text } from "@chakra-ui/react";
+
+export const AMITableFootnote = () => (
+  <TableCaption>
+    <Text>
+      *AMI, or Area Median Income, refers to U.S. Housing and Urban Development
+      annual Income Limits for New York City. HUD establishes these Income
+      Limits each year to administer federal housing funds, such as housing tax
+      credits and rental assistance benefits. Each metropolitan area has unique
+      Income Limits. In government-administered affordable housing, these Income
+      Limits establish maximum eligible household incomes for new rentals or
+      homes for sale.
+    </Text>
+    <Text>
+      In New York City, because housing costs are so high, Income Limits are not
+      calculated using New Yorkers’ incomes. In NYC, Income Limits are based on
+      the income needed to afford currently available market rate housing. Learn
+      more about how HUD calculates NYC’s 2022 Income Limits here:{" "}
+      <Link
+        href="https://www.huduser.gov/portal/datasets/il/il2022/2022IlCalc.odn"
+        isExternal
+      >
+        FY 2022 Income Limits Documentation System -- Income Limits Calculations
+        for New York, NY HUD Metro FMR Area (huduser.gov)
+      </Link>
+    </Text>
+  </TableCaption>
+);

--- a/src/components/VintageTable/Footnote/index.ts
+++ b/src/components/VintageTable/Footnote/index.ts
@@ -1,0 +1,1 @@
+export * from "./AMITableFootnote";

--- a/src/components/VintageTable/VintageTableDesktop.tsx
+++ b/src/components/VintageTable/VintageTableDesktop.tsx
@@ -25,7 +25,7 @@ const VintageTableDesktop = ({
     isChange: boolean;
   }[] = vintages.map((vintage) => {
     const headers = vintage.headers;
-    // When the header is a survey and the reliability inidicators are off,
+    // When the header is a survey and the reliability indicators are off,
     // then the headers should take the length of its first row of headers.
     // Otherwise, it should take the length of its longest row of headers.
     const titleColSpan = surveyShouldNotShowReliability
@@ -65,10 +65,10 @@ const VintageTableDesktop = ({
   });
 
   // Each body from every vintage needs to be collected into a cross-vintage row
-  // Meta contaings Data about the whole row and is based on the first vintage
+  // Meta contains Data about the whole row and is based on the first vintage
   // colspans and cells contain data for each datapoint
   // When a vintage contains 'null' for its cells, the data on how many columns
-  // that vintage should be is lost. The data are recoverd by looking at the
+  // that vintage should be is lost. The data are recovered by looking at the
   // colSpans of the header title for that vintage.
   const vintagesBodyRows: {
     meta: {

--- a/src/components/VintageTable/VintageTableDesktop.tsx
+++ b/src/components/VintageTable/VintageTableDesktop.tsx
@@ -1,18 +1,11 @@
-import {
-  Table,
-  Tbody,
-  Thead,
-  Td,
-  Th,
-  Tr,
-  TableCaption,
-} from "@chakra-ui/react";
+import { Table, Tbody, Thead, Td, Th, Tr } from "@chakra-ui/react";
 import { Vintage } from "@schemas/vintage";
 import { HeaderCell } from "@schemas/headerCell";
 import { DataPointCell } from "@components/DataPointCell";
 import { PercentDataPointCell } from "@components/PercentDataPointCell.tsx";
 import { DataPoint } from "@schemas/dataPoint";
 import { Footnote } from "@schemas/footnote";
+import { AMITableFootnote } from "./Footnote";
 
 export interface VintageTableDesktopProps {
   footnote: Footnote;
@@ -144,9 +137,7 @@ const VintageTableDesktop = ({
         width: "auto",
       }}
     >
-      <TableCaption>
-        {footnote != null ? "Not Null" : "Null"}Table Caption
-      </TableCaption>
+      {footnote === "AMI" ? <AMITableFootnote /> : <></>}
       <Thead>
         <Tr display="table-row">
           {/* Top left cornerstone */}

--- a/src/components/VintageTable/VintageTableDesktop.tsx
+++ b/src/components/VintageTable/VintageTableDesktop.tsx
@@ -137,7 +137,7 @@ const VintageTableDesktop = ({
         width: "auto",
       }}
     >
-      {footnote === "AMI" ? <AMITableFootnote /> : <></>}
+      <AMITableFootnote shouldDisplay={footnote === "AMI"} />
       <Thead>
         <Tr display="table-row">
           {/* Top left cornerstone */}

--- a/src/components/VintageTable/VintageTableDesktop.tsx
+++ b/src/components/VintageTable/VintageTableDesktop.tsx
@@ -1,17 +1,28 @@
-import { Table, Tbody, Thead, Td, Th, Tr } from "@chakra-ui/react";
+import {
+  Table,
+  Tbody,
+  Thead,
+  Td,
+  Th,
+  Tr,
+  TableCaption,
+} from "@chakra-ui/react";
 import { Vintage } from "@schemas/vintage";
 import { HeaderCell } from "@schemas/headerCell";
 import { DataPointCell } from "@components/DataPointCell";
 import { PercentDataPointCell } from "@components/PercentDataPointCell.tsx";
 import { DataPoint } from "@schemas/dataPoint";
+import { Footnote } from "@schemas/footnote";
 
 export interface VintageTableDesktopProps {
+  footnote: Footnote;
   vintages: Vintage[];
   shouldShowReliability: boolean;
   isSurvey: boolean;
 }
 
 const VintageTableDesktop = ({
+  footnote,
   vintages,
   shouldShowReliability,
   isSurvey,
@@ -133,6 +144,9 @@ const VintageTableDesktop = ({
         width: "auto",
       }}
     >
+      <TableCaption>
+        {footnote != null ? "Not Null" : "Null"}Table Caption
+      </TableCaption>
       <Thead>
         <Tr display="table-row">
           {/* Top left cornerstone */}

--- a/src/components/VintageTable/VintageTableMobile.tsx
+++ b/src/components/VintageTable/VintageTableMobile.tsx
@@ -4,14 +4,18 @@ import { ChevronDownIcon } from "@chakra-ui/icons";
 import { DataPointRow } from "@components/DataPointRow";
 import { Vintage } from "@schemas/vintage";
 import { useTablesIsOpen } from "@contexts/TablesIsOpenContext";
+import { Footnote } from "@schemas/footnote";
+import { AMITableFootnote } from "./Footnote";
 
 export interface VintageTableMobileProps {
+  footnote: Footnote;
   vintage: Vintage;
   shouldShowReliability: boolean;
   isSurvey: boolean;
 }
 
 const VintageTableMobile = ({
+  footnote,
   vintage,
   shouldShowReliability,
   isSurvey,
@@ -37,6 +41,7 @@ const VintageTableMobile = ({
         width: "auto",
       }}
     >
+      <AMITableFootnote shouldDisplay={footnote === "AMI"} />
       <Thead>
         <Tr>
           <Th

--- a/src/components/VintageTable/VintageTableMobile.tsx
+++ b/src/components/VintageTable/VintageTableMobile.tsx
@@ -41,7 +41,7 @@ const VintageTableMobile = ({
         width: "auto",
       }}
     >
-      <AMITableFootnote shouldDisplay={footnote === "AMI"} />
+      <AMITableFootnote shouldDisplay={isOpen && footnote === "AMI"} />
       <Thead>
         <Tr>
           <Th

--- a/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
@@ -110,7 +110,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
     };
   }
 
-  const spaceFolder = "2023-05-05--v1";
+  const spaceFolder = "2023-05-05--v2";
   const dataExplorerService = new DataExplorerService(
     process.env.NEXT_PUBLIC_DO_SPACE_URL
       ? `${process.env.NEXT_PUBLIC_DO_SPACE_URL}/app/${spaceFolder}`

--- a/src/schemas/footnote.ts
+++ b/src/schemas/footnote.ts
@@ -1,0 +1,5 @@
+import { InferType, string } from "yup";
+
+export const footnoteSchema = string().nullable();
+
+export type Footnote = InferType<typeof footnoteSchema>;

--- a/src/schemas/indicatorRecord.ts
+++ b/src/schemas/indicatorRecord.ts
@@ -1,8 +1,10 @@
 import { object, string, array, InferType, boolean } from "yup";
 import { vintageSchema } from "@schemas/vintage";
+import { footnoteSchema } from "./footnote";
 
 export const indicatorRecordSchema = object({
   title: string().required(),
+  footnote: footnoteSchema,
   id: string().nullable(),
   isSurvey: boolean().required(),
   vintages: array().of(vintageSchema).required(),


### PR DESCRIPTION
### Summary
- Add a footnote to provide context on Area Median Income contexts
- On mobile version, hide footnote when the table is collapsed
- Point to `2023-05-05--v2` DO folder

#### Tasks/Bug Numbers
- Closes [AB#13262](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/13262)

### Technical Explanation
- Look for a new footnote property with value of "AMI" that is prop-drilled from indicator to table
- When footnote is present, add a Chakra Table Caption

### Any other info you think would help a reviewer understand this PR?
Relates to [ose-equity-tool pull 34](https://github.com/NYCPlanning/ose-equity-tool-etl/pull/34)
