### PR TITLE
Task/13262 footnote on page

### DIFF
--- a/src/components/Footnote/AMIFootnote.tsx
+++ b/src/components/Footnote/AMIFootnote.tsx
@@ -1,0 +1,48 @@
+import { Box, Link, Text } from "@chakra-ui/react";
+
+interface AMITableFootnoteProps {
+  shouldDisplay: boolean;
+}
+
+export const AMIFootnote = ({ shouldDisplay }: AMITableFootnoteProps) =>
+  shouldDisplay ? (
+    <Box>
+      <Text
+        align="left"
+        padding={1}
+        fontStyle="italic"
+        fontSize="md"
+        color={"gray"}
+      >
+        *AMI, or Area Median Income, refers to U.S. Housing and Urban
+        Development annual Income Limits for New York City. HUD establishes
+        these Income Limits each year to administer federal housing funds, such
+        as housing tax credits and rental assistance benefits. Each metropolitan
+        area has unique Income Limits. In government-administered affordable
+        housing, these Income Limits establish maximum eligible household
+        incomes for new rentals or homes for sale.
+      </Text>
+      <Text
+        align="left"
+        padding={1}
+        fontStyle="italic"
+        fontSize="md"
+        color={"gray"}
+      >
+        In New York City, because housing costs are so high, Income Limits are
+        not calculated using New Yorkers’ incomes. In NYC, Income Limits are
+        based on the income needed to afford currently available market rate
+        housing. Learn more about how HUD calculates NYC’s 2022 Income Limits
+        here:{" "}
+        <Link
+          href="https://www.huduser.gov/portal/datasets/il/il2022/2022IlCalc.odn"
+          isExternal
+        >
+          FY 2022 Income Limits Documentation System -- Income Limits
+          Calculations for New York, NY HUD Metro FMR Area (huduser.gov)
+        </Link>
+      </Text>
+    </Box>
+  ) : (
+    <></>
+  );

--- a/src/components/Footnote/index.ts
+++ b/src/components/Footnote/index.ts
@@ -1,0 +1,1 @@
+export * from "./AMIFootnote";

--- a/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
@@ -111,7 +111,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
     };
   }
 
-  const spaceFolder = "2023-05-05--v1";
+  const spaceFolder = "2023-05-05--v3";
   const dataExplorerService = new DataExplorerService(
     process.env.NEXT_PUBLIC_DO_SPACE_URL
       ? `${process.env.NEXT_PUBLIC_DO_SPACE_URL}/app/${spaceFolder}`

--- a/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
+++ b/src/pages/data/[geography]/[geoid]/[category]/[subgroup].tsx
@@ -42,6 +42,7 @@ import { TablesIsOpenProvider } from "@contexts/TablesIsOpenContext";
 import { Geography } from "@constants/geography";
 import { useWindowWidth } from "@react-hook/window-size";
 import { View } from "@constants/View";
+import { AMIFootnote } from "@components/Footnote";
 
 export interface DataPageProps {
   indicators: IndicatorRecord[];
@@ -386,6 +387,13 @@ const DataPage = ({ indicators, geoid }: DataPageProps) => {
               />
             ))}
           </TablesIsOpenProvider>
+          <AMIFootnote
+            shouldDisplay={[
+              Category.ECON,
+              Category.HSAQ,
+              Category.HOPD,
+            ].includes(category)}
+          />
         </Box>
       </Box>
     </Flex>


### PR DESCRIPTION
### Summary
- Add a footnote to category pages that have tables with Area Median Income contexts
- Point to `2023-05-05--v3` DO folder

#### Tasks/Bug Numbers
- Closes [AB#13262](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/13262)

### Technical Explanation
- List category pages that have tables with AMI headers

### Any other info you think would help a reviewer understand this PR?
Relates to [ose-equity-tool pull 35](https://github.com/NYCPlanning/ose-equity-tool-etl/pull/35)
