### PR TITLE
Task/245 Additional Layers Text is Cut Off

### DIFF
--- a/src/components/AdditionalMapLayers/AdditionalLayersPanel.tsx
+++ b/src/components/AdditionalMapLayers/AdditionalLayersPanel.tsx
@@ -14,6 +14,7 @@ import {
 } from "@components/Icons";
 import { View } from "@constants/View";
 import { useView } from "@hooks/useView";
+import { useIsWindows } from "@hooks/useIsWIndows/useIsWIndows";
 
 export interface AdditionalLayersPanelProps {
   onToggleNtaLayer: () => void;
@@ -25,13 +26,14 @@ export const AdditionalLayersPanel = ({
   onToggleDistrictLayer,
 }: AdditionalLayersPanelProps) => {
   const view = useView();
+  const isWindows = useIsWindows();
 
   return (
     <IconPanel
       heading="Additional Layers"
       icon={<MapLayersIcon />}
       aria-label="Show additional map layer options"
-      height={{ base: "204px", md: "180px" }}
+      height={{ base: "204px", md: isWindows ? "200px" : "180px" }}
       top={{
         base: view === View.DATA ? "11rem" : "7.75rem",
         md: view === View.DATA ? "14.5rem" : "11rem",

--- a/src/hooks/useIsWIndows/index.js
+++ b/src/hooks/useIsWIndows/index.js
@@ -1,0 +1,1 @@
+export * from "./useIsWindows";

--- a/src/hooks/useIsWIndows/useIsWIndows.ts
+++ b/src/hooks/useIsWIndows/useIsWIndows.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from "react";
+
+export const useIsWindows = (): boolean => {
+  const [isWindows, setIsWindows] = useState(false);
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && window.navigator?.userAgent) {
+      const isWin = window.navigator.userAgent
+        .toLowerCase()
+        .includes("windows");
+      setIsWindows(isWin);
+    }
+  }, []);
+
+  return isWindows;
+};


### PR DESCRIPTION
### Summary
Added a helper function to detect is a user is on a Windows OS and set the height to 200px to accommodate the Additional Layers copy

#### Tasks/Bug Numbers
 - Closes #245 

####  Testing / QA 
Test using Chrome and Edge on a Windows machine, either on Guest WiFi or other WiFi connection(s).
The link to the review deploy does not work on the city network. It is blocked by the proxy / firewall.


[Review App](https://0e1b63--equity-tool.netlify.app/)

