### PR TITLE
276 Remove Link to Storymaps

### DIFF
--- a/src/components/Map/InstructionPanel.tsx
+++ b/src/components/Map/InstructionPanel.tsx
@@ -1,4 +1,4 @@
-import { Box, HStack, Text, Square, Link } from "@chakra-ui/react";
+import { Box, HStack, Text, Square } from "@chakra-ui/react";
 import { InfoIcon } from "@chakra-ui/icons";
 import { IconPanel } from "@components/Map/IconPanel";
 import { useView } from "@hooks/useView";
@@ -32,17 +32,7 @@ export const InstructionPanel = () => {
         >
           Select a neighborhood to see a breakdown of the factors contributing
           to displacement risk (population vulnerability, housing conditions,
-          and market pressure) and the data points that comprise them. See maps
-          of each of the individual data points{" "}
-          <Link
-            fontWeight={700}
-            color="000"
-            href="https://storymaps.arcgis.com/stories/79237333bb90492ba0de486c0705f9f7"
-            target="blank"
-          >
-            here
-          </Link>
-          .
+          and market pressure) and the data points that comprise them.
         </Text>
       )}
 

--- a/src/components/WelcomeContent.tsx
+++ b/src/components/WelcomeContent.tsx
@@ -1,7 +1,6 @@
-import { Heading, Text, Link } from "@chakra-ui/react";
+import { Heading, Text } from "@chakra-ui/react";
 import { View } from "@constants/View";
 import { useView } from "@hooks/useView";
-import ReactGA from "react-ga4";
 
 const WelcomeContent = () => {
   const view = useView();
@@ -55,21 +54,7 @@ const WelcomeContent = () => {
           displacement risk in neighborhoods citywide as compared to each other.
           Select a neighborhood to see a breakdown of the factors contributing
           to displacement risk (population vulnerability, housing conditions,
-          and market pressure) and the data points that comprise them. See maps
-          of each of the individual data points&nbsp;
-          <Link
-            href="https://storymaps.arcgis.com/stories/79237333bb90492ba0de486c0705f9f7"
-            onClick={() => {
-              ReactGA.event({
-                category: "DRM Sidebar",
-                action: "Outbound Click",
-                label: "Storymaps",
-              });
-            }}
-          >
-            here
-          </Link>
-          .
+          and market pressure) and the data points that comprise them.
         </Text>
         <br />
         <Text>


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
Would it be possible to just delete this sentence of text including the hyperlink from the Displacement Risk Map? we haven't updated the storymap that the link directs to, so we want to remove it for now. thank you so much!! 
<img width="1916" height="916" alt="Image" src="https://github.com/user-attachments/assets/60e391c9-d30e-4de9-9ef5-617e3466c05e" />

#### Tasks/Bug Numbers
 - Closes #276 